### PR TITLE
Remove dependency on search-api

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,7 +12,6 @@ from config import configs
 
 login_manager = LoginManager()
 data_api_client = dmapiclient.DataAPIClient()
-search_api_client = dmapiclient.SearchAPIClient()
 feature_flags = flask_featureflags.FeatureFlag()
 csrf = CsrfProtect()
 
@@ -28,7 +27,6 @@ def create_app(config_name):
         data_api_client=data_api_client,
         feature_flags=feature_flags,
         login_manager=login_manager,
-        search_api_client=search_api_client
     )
 
     for framework_data in data_api_client.find_frameworks().get('frameworks'):

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,7 +1,7 @@
 from flask import jsonify, current_app, request
 
 from . import status
-from .. import data_api_client, search_api_client
+from .. import data_api_client
 from dmutils.status import get_flags
 
 
@@ -19,11 +19,7 @@ def status():
             'name': '(Data) API',
             'key': 'api_status',
             'status': data_api_client.get_status()
-        }, {
-            'name': 'Search API',
-            'key': 'search_api_status',
-            'status': search_api_client.get_status()
-        }
+        },
     ]
 
     apis_with_errors = []

--- a/config.py
+++ b/config.py
@@ -32,12 +32,7 @@ class Config(object):
 
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
-    DM_SEARCH_API_URL = None
-    DM_SEARCH_API_AUTH_TOKEN = None
     DM_MANDRILL_API_KEY = None
-
-    # matches api(s)
-    DM_SEARCH_PAGE_SIZE = 100
 
     # This is just a placeholder
     ES_ENABLED = True
@@ -100,8 +95,6 @@ class Test(Config):
 
     DM_DATA_API_URL = "http://wrong.completely.invalid:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"
-    DM_SEARCH_API_URL = "http://wrong.completely.invalid:5001"
-    DM_SEARCH_API_AUTH_TOKEN = "myToken"
 
     DM_MANDRILL_API_KEY = 'MANDRILL'
     SHARED_EMAIL_KEY = "KEY"
@@ -114,12 +107,9 @@ class Development(Config):
     DEBUG = True
     DM_PLAIN_TEXT_LOGS = True
     SESSION_COOKIE_SECURE = False
-    DM_SEARCH_PAGE_SIZE = 5
 
     DM_DATA_API_URL = "http://localhost:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"
-    DM_SEARCH_API_URL = "http://localhost:5001"
-    DM_SEARCH_API_AUTH_TOKEN = "myToken"
 
     DM_MANDRILL_API_KEY = "not_a_real_key"
     SECRET_KEY = "verySecretKey"


### PR DESCRIPTION
Briefs aren't using search-api, so we can remove the api client
instance, config variables and the status endpoint check.