### PR TITLE
Preserve line breaks for textarea formatted text

### DIFF
--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -71,7 +71,9 @@
               {{ summary.text("Not answered") }}
             {% endif %}
           {% else %}
-            {{ summary[question.type](question.display_value or question.value) }}
+            {% with question_value = summary[question.type](question.display_value or question.value) %}
+              {{ (question_value | preserve_line_breaks) if question.type == 'textbox_large' else question_value }}
+            {% endwith %}
           {% endif %}
 
           {% if brief.get('status') == 'draft' %}

--- a/app/templates/buyers/supplier_questions.html
+++ b/app/templates/buyers/supplier_questions.html
@@ -52,9 +52,9 @@
         {% call summary.row() %}
           {% call summary.field(first=True, wide=False) -%}
             <span aria-label="question">{{ question.number }}.</span>
-            {{ question.question }}
+            {{ question.question | preserve_line_breaks }}
           {%- endcall %}
-          {{ summary.text(question.answer) }}
+          {{ summary.text(question.answer) | preserve_line_breaks }}
         {% endcall %}
       {% endcall %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ unicodecsv==0.14.1
 werkzeug==0.10.4
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@26.2.1#egg=digitalmarketplace-utils==26.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.0#egg=digitalmarketplace-utils==27.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.8.0#egg=digitalmarketplace-apiclient==8.8.0


### PR DESCRIPTION
We're bringing in a new jinja filter that keeps line breaks (up to a maximum of two) for the large textarea content.

Specifically, it's going into:

- the briefs summary table when displaying a `textbox_large` questions for a brief (buyers see this when they are creating their briefs) 
- the questions and answers summary table that buyers see before adding a new question+answer to a brief

## example

### with this json 

```json
  {"workplaceAddress": "Primary location to be:\r\n\r\nApplication Services 
      & DevOps Tower (ASDT),\r\nMOD Corsham,\r\nWestwells Road,\r\nCorsham,
      \r\nWiltshire,\r\nSN13 9NR\r\n\r\nDue to the nature of the work to be 
      delivered there will be a need to visit other locations including London, 
      Lichfield, Bristol and Leeds."
  }
```
<sub>ie, [Programme CORTISONE - Scrum Master](https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/19)</sub>

### before

![screen shot 2017-06-29 at 15 39 36](https://user-images.githubusercontent.com/2454380/27693407-50a43158-5ce1-11e7-808d-0c59e5115589.png)

### after

![screen shot 2017-06-29 at 15 40 04](https://user-images.githubusercontent.com/2454380/27693417-570fb3f0-5ce1-11e7-9bc6-c6ebca43b81e.png)
