### PR TITLE
Display time opportunity closes

### DIFF
--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -77,8 +77,8 @@
               'title': 'Publish requirements',
               'description': {
                 'draft': '',
-                'live': 'Your requirements are open for applications until {}.'.format(brief.applicationsClosedAt | dateformat),
-                'closed': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | dateformat),
+                'live': 'Your requirements are open for applications until {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
+                'closed': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
               },
               'links': [
                 {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.8.0#egg=digitalmarketplace-apiclient==8.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.8.0#egg=digitalmarketplace-apiclient==8.8.0
 


### PR DESCRIPTION
Use the new `utcdatetimeformat` filter when displaying closing dates on the brief overview.

Also took the opportunity to add a tiny bit of test coverage in the `test_buyers` module 😄 

See the buyer-frontend pull request for more details (https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/560) 

Ticket: https://trello.com/c/8CJAv25W/714-show-time-opportunity-closes 