### PR TITLE
Apply UTC date format to publish confirmation page

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -47,7 +47,7 @@
         {% else %}
           <p>Your requirements will be open for {{ dates.application_open_weeks }}.</p>
           <div class="dmspeak">
-            <p>If you publish your requirements today ({{ dates.published_date | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
+            <p>If you publish your requirements today ({{ dates.published_date | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_date | utcdatetimeformat }}.</p>
           </div>
         {% endif %}
     {% endif %}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ mock==2.0.0
 lxml==3.4.4
 cssselect==0.9.1
 watchdog==0.8.3
+freezegun==0.3.4
 
 coverage==3.7.1
 pytest-cov==2.2.0

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -11,6 +11,7 @@ import pytest
 
 from app.main.views import buyers
 from dmapiclient import DataAPIClient
+from freezegun import freeze_time
 import functools
 import inflection
 import sys
@@ -1368,14 +1369,17 @@ class TestPublishBrief(BaseApplicationTest):
         })
         data_api_client.get_brief.return_value = brief_json
 
-        res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
-                              "digital-specialists/1234/publish")
-        page_html = res.get_data(as_text=True)
+        with freeze_time('2016-12-31 23:59:59'):
+            res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                                  "digital-specialists/1234/publish")
+            page_html = res.get_data(as_text=True)
 
         assert res.status_code == 200
         assert 'Your requirements will be open for 1 week.' in page_html
         assert 'This will show you what the supplier application deadline will be' not in page_html
         assert 'Your requirements will be open for 2 weeks' not in page_html
+        assert 'If you publish your requirements today (31 December)' in page_html
+        assert 'suppliers will be able to apply until Saturday 7 January 2017 at 11:59pm GMT' in page_html
 
     def test_correct_content_is_displayed_if_requirementLength_is_2_weeks(self, data_api_client):
         self.login_as_buyer()
@@ -1394,14 +1398,17 @@ class TestPublishBrief(BaseApplicationTest):
         })
         data_api_client.get_brief.return_value = brief_json
 
-        res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
-                              "digital-specialists/1234/publish")
-        page_html = res.get_data(as_text=True)
+        with freeze_time('2017-07-17 23:59:59'):
+            res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                                  "digital-specialists/1234/publish")
+            page_html = res.get_data(as_text=True)
 
         assert res.status_code == 200
         assert 'Your requirements will be open for 2 weeks.' in page_html
         assert 'This will show you what the supplier application deadline will be' not in page_html
         assert 'Your requirements will be open for 1 week' not in page_html
+        assert 'If you publish your requirements today (17 July)' in page_html
+        assert 'suppliers will be able to apply until Monday 31 July 2017 at 11:59pm GMT' in page_html
 
     def test_correct_content_is_displayed_if_requirementLength_is_not_set(self, data_api_client):
         self.login_as_buyer()


### PR DESCRIPTION
Includes test coverage to assert the date has been formatted correctly for both GMT and BST datestamps. This required adding freezegun to the test dependencies, so we can check that the dates are displayed using GMT.

Ticket: https://trello.com/c/8CJAv25W/714-show-time-opportunity-closes