### PR TITLE
Static URL path for briefs application

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,9 @@ content_loader = ContentLoader('app/content')
 
 
 def create_app(config_name):
-    application = Flask(__name__)
+    application = Flask(__name__,
+                        static_folder='static/',
+                        static_url_path=configs[config_name].STATIC_URL_PATH)
 
     init_app(
         application,

--- a/config.py
+++ b/config.py
@@ -49,7 +49,8 @@ class Config(object):
     RESET_PASSWORD_SALT = 'ResetPasswordSalt'
     INVITE_EMAIL_SALT = 'InviteEmailSalt'
 
-    ASSET_PATH = '/static/'
+    STATIC_URL_PATH = '/buyers/static'
+    ASSET_PATH = STATIC_URL_PATH + '/'
     BASE_TEMPLATE_DATA = {
         'header_class': 'with-proposition',
         'asset_path': ASSET_PATH,


### PR DESCRIPTION
After splitting the `briefs-frontend` and `buyer-frontend` apps, we missed adding the static URL path to the briefs Flask app. This meant the briefs app was falling back to the `buyer-frontend` stylesheet - which contains some backwards incompatibilities 😱 

Info on the fix to avoid this in future has been added to the manual: https://github.com/alphagov/digitalmarketplace-manual/pull/8 

Ticket: https://trello.com/c/w7V48v7h/762-1-radio-button-lists-styling-broken-on-preview