### PR TITLE
Add create-your-account-complete endpoint and template

### DIFF
--- a/app/create_buyer/views/create_buyer.py
+++ b/app/create_buyer/views/create_buyer.py
@@ -70,10 +70,18 @@ def submit_create_buyer_account():
                 audit_type=AuditTypes.invite_user,
                 data={'invitedEmail': email_address})
 
-            return redirect(url_for('external.create_your_account_complete'), 302)
+            return redirect(url_for('.create_your_account_complete'), 302)
     else:
         return render_template(
             "create_buyer/create_buyer_account.html",
             form=form,
             email_address=form.email_address.data
         ), 400
+
+
+@create_buyer.route('/create-your-account-complete', methods=['GET'])
+def create_your_account_complete():
+    email_address = session.setdefault("email_sent_to", "the email address you supplied")
+    return render_template(
+        "create_buyer/create_your_account_complete.html",
+        email_address=email_address), 200

--- a/app/external/views/external.py
+++ b/app/external/views/external.py
@@ -13,11 +13,6 @@ def create_user(encoded_token):
     raise NotImplementedError()
 
 
-@external.route('/create-your-account-complete')
-def create_your_account_complete():
-    raise NotImplementedError()
-
-
 @external.route('/login')
 def render_login():
     raise NotImplementedError()

--- a/app/templates/create_buyer/create_your_account_complete.html
+++ b/app/templates/create_buyer/create_your_account_complete.html
@@ -1,0 +1,39 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block page_title %}Activate your account - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+{%
+  with items = [
+    {
+    "link": "/",
+    "label": "Digital Marketplace"
+    }
+  ]
+%}
+{% include "toolkit/breadcrumb.html" %}
+{% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="single-question-page">
+  {%
+    with
+      heading = "Activate your account"
+  %}
+  {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <p>
+        An email has been sent to {{ email_address }}.
+        You need to click on the link in the email to activate your account.
+      </p>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/tests/create_buyers/views/test_create_buyers.py
+++ b/tests/create_buyers/views/test_create_buyers.py
@@ -22,7 +22,14 @@ class TestBuyersCreation(BaseApplicationTest):
             follow_redirects=False
         )
         assert res.status_code == 302
-        assert res.location == 'http://localhost/create-your-account-complete'
+        assert res.location == 'http://localhost/buyers/create-your-account-complete'
+
+    def test_create_your_account_complete_page(self):
+        res = self.client.get(
+            '/buyers/create-your-account-complete',
+            follow_redirects=False
+        )
+        assert res.status_code == 200
 
     @mock.patch('app.create_buyer.views.create_buyer.send_email')
     @mock.patch('app.create_buyer.views.create_buyer.data_api_client')


### PR DESCRIPTION
Most of the buyer account creation flow is part of the briefs frontend
at the moment, but since the "check your email" page URL wasn't prefixed
with `/buyers` it was left in the buyer frontend.

This moves it to the rest of the buyer account creation pages and
changes the URL to be prefixed with `/buyers/`.