### PR TITLE
Backwards compatibility for new Brief statuses

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -29,8 +29,8 @@ from io import BytesIO
 
 from collections import Counter
 
-CLOSED_BRIEF_STATUSES = ['closed', 'withdrawn', 'awarded']
-CLOSED_PUBLISHED_BRIEF_STATUSES = ['closed', 'awarded']
+CLOSED_BRIEF_STATUSES = ['closed', 'withdrawn', 'awarded', 'cancelled', 'unsuccessful']
+CLOSED_PUBLISHED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
 
 
 @main.route('')

--- a/app/templates/buyers/_requirements_meta.html
+++ b/app/templates/buyers/_requirements_meta.html
@@ -1,7 +1,7 @@
 <div id="requirements-meta">
   <h2 class="sidebar-heading">Published</h2>
   <p class="sidebar-content">{{ brief.publishedAt|dateformat }}</p>
-  <h2 class="sidebar-heading">{% if brief.status in ['closed', 'awarded'] %}Closed{% else %}Closing{% endif %}</h2>
+  <h2 class="sidebar-heading">{% if brief.status in ['closed', 'awarded', 'cancelled', 'unsuccessful'] %}Closed{% else %}Closing{% endif %}</h2>
   <p class="sidebar-content">{{ brief.applicationsClosedAt|dateformat }}</p>
   <h2 class="sidebar-heading">Framework</h2>
   <p class="framework-name"><a href="{{ framework_agreement_url }}">{{ brief.frameworkName }}</a></p>

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -64,6 +64,8 @@
                 'live': 'Done',
                 'closed': 'Done',
                 'awarded': 'Done',
+                'cancelled': 'Done',
+                'unsuccessful': 'Done',
               },
             },
             {
@@ -73,6 +75,8 @@
                 'live': 'Done',
                 'closed': 'Done',
                 'awarded': 'Done',
+                'cancelled': 'Done',
+                'unsuccessful': 'Done',
               },
             },
             {
@@ -82,6 +86,8 @@
                 'live': 'Your requirements are open for applications until {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
                 'closed': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
                 'awarded': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
+                'cancelled': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
+                'unsuccessful': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
               },
               'links': [
                 {
@@ -97,7 +103,7 @@
                 {
                   'href': url_for("external.get_brief_by_id", framework_framework=brief.frameworkFramework, brief_id=brief.id),
                   'text': 'View your published requirements',
-                  'allowed_statuses': ['live', 'closed', 'awarded']
+                  'allowed_statuses': ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful']
                 }
               ]
             },
@@ -108,6 +114,8 @@
                 'live': 'You must answer all questions by {}. Suppliers will send you questions by email.'.format(brief.clarificationQuestionsPublishedBy | dateformat),
                 'closed': 'Done',
                 'awarded': 'Done',
+                'cancelled': 'Done',
+                'unsuccessful': 'Done',
               },
               'links': [
                 {
@@ -129,12 +137,14 @@
                 'live': 'After the application deadline, shortlist the suppliers who applied.',
                 'closed': 'You can view and shortlist suppliers who best meet your needs.',
                 'awarded': 'You can view and shortlist suppliers who best meet your needs.',
+                'cancelled': 'You can view and shortlist suppliers who best meet your needs.',
+                'unsuccessful': 'You can view and shortlist suppliers who best meet your needs.',
               },
               'links': [
                 {
                   'href': url_for(".view_brief_responses", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'View and shortlist suppliers',
-                  'allowed_statuses': ['closed', 'awarded']
+                  'allowed_statuses': ['closed', 'awarded', 'cancelled', 'unsuccessful']
                 },
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers',

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -139,7 +139,7 @@
           {{ summary.service_link(item.title, url_for("external.get_brief_by_id", framework_framework=item.frameworkFramework, brief_id=item.id)) }}
           {{ summary.text("Withdrawn") }}
           {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
-        {% elif item.status == "awarded" %}
+        {% elif item.status in ["awarded", "cancelled", "unsuccessful"] %}
           {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
           {{ summary.text(item.applicationsClosedAt|dateformat) }}
           {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ odfpy==1.3.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.14.0#egg=digitalmarketplace-apiclient==8.14.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.1.0#egg=digitalmarketplace-apiclient==10.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ odfpy==1.3.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.14.0#egg=digitalmarketplace-apiclient==8.14.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.1.0#egg=digitalmarketplace-apiclient==10.1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.22.0
@@ -42,7 +42,7 @@ python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
 requests==2.7.0
-s3transfer==0.1.10
+s3transfer==0.1.11
 six==1.9.0
 unicodecsv==0.14.1
 Werkzeug==0.12.2


### PR DESCRIPTION
Fifth of 5 backwards compatibility PRs to handle the two new Brief statuses, `cancelled` and `unsuccessful`.

1. Admin FE alphagov/digitalmarketplace-admin-frontend#293
2. Buyer FE alphagov/digitalmarketplace-buyer-frontend#588
3. Scripts alphagov/digitalmarketplace-scripts#144
4. Brief Responses FE https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/5
5. Briefs FE

See #12 for the equivalent changes for the awarded status (although that PR contains new functionality as well as backwards compatibility).