### PR TITLE
Brief overview page to support awarded, cancelled and unsuccessful statuses

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -176,6 +176,11 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
         abort(404)
 
+    awarded_brief_response_supplier_name = ""
+    if brief.get('awardedBriefResponseId'):
+        awarded_brief_response_supplier_name = data_api_client.get_brief_response(
+            brief['awardedBriefResponseId'])["briefResponses"]["supplierName"]
+
     content = content_loader.get_manifest(brief['frameworkSlug'], 'edit_brief').filter({'lot': brief['lotSlug']})
     sections = content.summary(brief)
     delete_requested = True if request.args.get('delete_requested') else False
@@ -208,6 +213,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
         delete_requested=delete_requested,
         call_off_contract_url=call_off_contract_url,
         framework_agreement_url=framework_agreement_url,
+        awarded_brief_response_supplier_name=awarded_brief_response_supplier_name
     ), 200
 
 

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -136,7 +136,7 @@
                 'draft': 'After the application deadline, shortlist the suppliers who applied.',
                 'live': 'After the application deadline, shortlist the suppliers who applied.',
                 'closed': '',
-                'awarded': '',
+                'awarded': 'Done',
                 'cancelled': '',
                 'unsuccessful': '',
               },
@@ -144,11 +144,17 @@
                 {
                   'href': url_for(".view_brief_responses", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'View and shortlist suppliers',
-                  'allowed_statuses': ['closed', 'awarded', 'cancelled', 'unsuccessful']
+                  'allowed_statuses': ['closed', 'cancelled', 'unsuccessful']
+                },
+                {
+                  'href': url_for(".view_brief_responses", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  'text': 'View suppliers who applied',
+                  'allowed_statuses': ['awarded']
                 },
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers',
                   'text': 'How to shortlist suppliers',
+                  'allowed_statuses': ['draft', 'live', 'closed', 'cancelled', 'unsuccessful']
                 }
               ]
             },
@@ -158,12 +164,13 @@
                 'draft': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
                 'live': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
                 'closed': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
-                'awarded': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
+                'awarded': 'Done',
               },
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers',
                   'text': 'How to evaluate suppliers',
+                  'allowed_statuses': ['draft', 'live', 'closed', 'cancelled', 'unsuccessful']
                 }
               ]
             },
@@ -173,16 +180,22 @@
                 'draft': 'You must give your chosen supplier a contract before they start work.',
                 'live': 'You must give your chosen supplier a contract before they start work.',
                 'closed': 'You must give your chosen supplier a contract before they start work.',
-                'awarded': 'You must give your chosen supplier a contract before they start work.',
+                'awarded': 'Done',
+              },
+              'body': {
+                'text': 'Awarded to ' + awarded_brief_response_supplier_name,
+                'allowed_statuses': ['awarded']
               },
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services',
                   'text': 'How to award a contract',
+                  'allowed_statuses': ['draft', 'live', 'closed', 'cancelled', 'unsuccessful']
                 },
                 {
                   'href': call_off_contract_url,
                   'text': "Download the " + brief.frameworkName + " contract",
+                  'allowed_statuses': ['draft', 'live', 'closed', 'cancelled', 'unsuccessful']
                 },
                 {
                   'href': url_for(".award_brief", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
@@ -203,8 +216,12 @@
             {% if step.description %}
               <p class="instruction-list-item-top">{{ step.description[brief.status] }}</p>
             {% endif %}
+            {% if step.body %}
+              {% if not step.body.allowed_statuses or brief.status in step.body.allowed_statuses %}
+                <p class="instruction-list-item-top">{{ step.body.text }}</p>
+              {% endif %}
+            {% endif %}
             {% if step_number in step_sections and brief.status == 'draft' %}
-
                 <ul class="instruction-list-item-top">
                   {% for section in sections %}
                     {% if section.step == step_number %}

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -42,10 +42,7 @@
   </div>
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-        heading = brief.get('title', brief['lotName']),
-        context = 'Overview'
-      %}
+      {% with heading = brief.get('title', brief['lotName']) %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
     </div>

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -84,10 +84,10 @@
               'description': {
                 'draft': '',
                 'live': 'Your requirements are open for applications until {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
-                'closed': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
-                'awarded': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
-                'cancelled': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
-                'unsuccessful': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | utcdatetimeformat),
+                'closed': 'Done',
+                'awarded': 'Done',
+                'cancelled': 'Done',
+                'unsuccessful': 'Done',
               },
               'links': [
                 {
@@ -135,10 +135,10 @@
               'description': {
                 'draft': 'After the application deadline, shortlist the suppliers who applied.',
                 'live': 'After the application deadline, shortlist the suppliers who applied.',
-                'closed': 'You can view and shortlist suppliers who best meet your needs.',
-                'awarded': 'You can view and shortlist suppliers who best meet your needs.',
-                'cancelled': 'You can view and shortlist suppliers who best meet your needs.',
-                'unsuccessful': 'You can view and shortlist suppliers who best meet your needs.',
+                'closed': '',
+                'awarded': '',
+                'cancelled': '',
+                'unsuccessful': '',
               },
               'links': [
                 {
@@ -182,8 +182,13 @@
                 },
                 {
                   'href': call_off_contract_url,
-                  'text': "View the " + brief.frameworkName + " contract",
+                  'text': "Download the " + brief.frameworkName + " contract",
                 },
+                {
+                  'href': url_for(".award_brief", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  'text': "Let suppliers know the outcome",
+                  'allowed_statuses': ['closed']
+                }
               ]
             }
           ]

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -137,24 +137,24 @@
                 'live': 'After the application deadline, shortlist the suppliers who applied.',
                 'closed': '',
                 'awarded': 'Done',
-                'cancelled': '',
-                'unsuccessful': '',
+                'cancelled': 'Done',
+                'unsuccessful': 'Done',
               },
               'links': [
                 {
                   'href': url_for(".view_brief_responses", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'View and shortlist suppliers',
-                  'allowed_statuses': ['closed', 'cancelled', 'unsuccessful']
+                  'allowed_statuses': ['closed']
                 },
                 {
                   'href': url_for(".view_brief_responses", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'View suppliers who applied',
-                  'allowed_statuses': ['awarded']
+                  'allowed_statuses': ['cancelled', 'unsuccessful', 'awarded']
                 },
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers',
                   'text': 'How to shortlist suppliers',
-                  'allowed_statuses': ['draft', 'live', 'closed', 'cancelled', 'unsuccessful']
+                  'allowed_statuses': ['draft', 'live', 'closed']
                 }
               ]
             },
@@ -165,12 +165,14 @@
                 'live': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
                 'closed': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
                 'awarded': 'Done',
+                'cancelled': 'Done',
+                'unsuccessful': 'Done',
               },
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers',
                   'text': 'How to evaluate suppliers',
-                  'allowed_statuses': ['draft', 'live', 'closed', 'cancelled', 'unsuccessful']
+                  'allowed_statuses': ['draft', 'live', 'closed']
                 }
               ]
             },
@@ -181,6 +183,8 @@
                 'live': 'You must give your chosen supplier a contract before they start work.',
                 'closed': 'You must give your chosen supplier a contract before they start work.',
                 'awarded': 'Done',
+                'cancelled': 'The contract was not awarded - the requirement was cancelled.',
+                'unsuccessful': 'The contract was not awarded - no suitable suppliers applied.',
               },
               'body': {
                 'text': 'Awarded to ' + awarded_brief_response_supplier_name,
@@ -190,12 +194,12 @@
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services',
                   'text': 'How to award a contract',
-                  'allowed_statuses': ['draft', 'live', 'closed', 'cancelled', 'unsuccessful']
+                  'allowed_statuses': ['draft', 'live', 'closed']
                 },
                 {
                   'href': call_off_contract_url,
                   'text': "Download the " + brief.frameworkName + " contract",
-                  'allowed_statuses': ['draft', 'live', 'closed', 'cancelled', 'unsuccessful']
+                  'allowed_statuses': ['draft', 'live', 'closed']
                 },
                 {
                   'href': url_for(".award_brief", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1780,9 +1780,12 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert not document.xpath('//a[contains(text(), "Delete")]')
 
     @pytest.mark.parametrize('framework_status', ['live', 'expired'])
-    @pytest.mark.parametrize('status', ['cancelled', 'unsuccessful'])
+    @pytest.mark.parametrize(
+        'status,award_description',
+        [('cancelled', 'the requirement was cancelled'), ('unsuccessful', 'no suitable suppliers applied')]
+    )
     def test_show_cancelled_and_unsuccessful_brief_summary_page_for_live_and_expired_framework(
-            self, data_api_client, status, framework_status):
+            self, data_api_client, status, award_description, framework_status):
         with self.app.app_context():
             self.login_as_buyer()
             data_api_client.get_framework.return_value = api_stubs.framework(
@@ -1809,12 +1812,9 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
             assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
                 'View your published requirements',
-                'View and shortlist suppliers',
-                'How to shortlist suppliers',
-                'How to evaluate suppliers',
-                'How to award a contract',
-                'Download the Digital Outcomes and Specialists contract',
+                'View suppliers who applied',
             ]
+            assert "The contract was not awarded - {}.".format(award_description) in page_html
 
             assert "Awarded to " not in page_html
             assert not document.xpath('//a[contains(text(), "Delete")]')

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1700,131 +1700,127 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Awarded to " not in page_html
             assert document.xpath('//a[contains(text(), "Delete")]')
 
-    def test_show_live_brief_summary_page_for_live_and_expired_framework(self, data_api_client):
-        framework_statuses = ['live', 'expired']
+    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
+    def test_show_live_brief_summary_page_for_live_and_expired_framework(self, data_api_client, framework_status):
         with self.app.app_context():
             self.login_as_buyer()
-            for framework_status in framework_statuses:
-                data_api_client.get_framework.return_value = api_stubs.framework(
-                    slug='digital-outcomes-and-specialists',
-                    status=framework_status,
-                    lots=[
-                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                    ]
-                )
-                brief_json = api_stubs.brief(status="live")
-                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-                brief_json['briefs']['specialistRole'] = 'communicationsManager'
-                brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-                data_api_client.get_brief.return_value = brief_json
-
-                res = self.client.get(
-                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
-                )
-
-                assert res.status_code == 200
-                page_html = res.get_data(as_text=True)
-                document = html.fromstring(page_html)
-
-                assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-                assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
-                    'View question and answer dates',
-                    'View your published requirements',
-                    'Publish questions and answers',
-                    'How to answer supplier questions',
-                    'How to shortlist suppliers',
-                    'How to evaluate suppliers',
-                    'How to award a contract',
-                    'Download the Digital Outcomes and Specialists contract',
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
                 ]
+            )
+            brief_json = api_stubs.brief(status="live")
+            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+            data_api_client.get_brief.return_value = brief_json
 
-                assert "Awarded to " not in page_html
-                assert not document.xpath('//a[contains(text(), "Delete")]')
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
+            )
 
-    def test_show_closed_brief_summary_page_for_live_and_expired_framework(self, data_api_client):
-        framework_statuses = ['live', 'expired']
+            assert res.status_code == 200
+            page_html = res.get_data(as_text=True)
+            document = html.fromstring(page_html)
+
+            assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
+            assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
+                'View question and answer dates',
+                'View your published requirements',
+                'Publish questions and answers',
+                'How to answer supplier questions',
+                'How to shortlist suppliers',
+                'How to evaluate suppliers',
+                'How to award a contract',
+                'Download the Digital Outcomes and Specialists contract',
+            ]
+
+            assert "Awarded to " not in page_html
+            assert not document.xpath('//a[contains(text(), "Delete")]')
+
+    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
+    def test_show_closed_brief_summary_page_for_live_and_expired_framework(self, data_api_client, framework_status):
         with self.app.app_context():
             self.login_as_buyer()
-            for framework_status in framework_statuses:
-                data_api_client.get_framework.return_value = api_stubs.framework(
-                    slug='digital-outcomes-and-specialists',
-                    status=framework_status,
-                    lots=[
-                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                    ]
-                )
-                brief_json = api_stubs.brief(status="closed")
-                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-                brief_json['briefs']['specialistRole'] = 'communicationsManager'
-                brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-                data_api_client.get_brief.return_value = brief_json
-
-                res = self.client.get(
-                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
-                )
-
-                assert res.status_code == 200
-                page_html = res.get_data(as_text=True)
-                document = html.fromstring(page_html)
-
-                assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-                assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
-                    'View your published requirements',
-                    'View and shortlist suppliers',
-                    'How to shortlist suppliers',
-                    'How to evaluate suppliers',
-                    'How to award a contract',
-                    'Download the Digital Outcomes and Specialists contract',
-                    'Let suppliers know the outcome'
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
                 ]
+            )
+            brief_json = api_stubs.brief(status="closed")
+            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+            data_api_client.get_brief.return_value = brief_json
 
-                assert "Awarded to " not in page_html
-                assert not document.xpath('//a[contains(text(), "Delete")]')
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
+            )
 
+            assert res.status_code == 200
+            page_html = res.get_data(as_text=True)
+            document = html.fromstring(page_html)
+
+            assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
+            assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
+                'View your published requirements',
+                'View and shortlist suppliers',
+                'How to shortlist suppliers',
+                'How to evaluate suppliers',
+                'How to award a contract',
+                'Download the Digital Outcomes and Specialists contract',
+                'Let suppliers know the outcome'
+            ]
+
+            assert "Awarded to " not in page_html
+            assert not document.xpath('//a[contains(text(), "Delete")]')
+
+    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
     @pytest.mark.parametrize('status', ['cancelled', 'unsuccessful'])
     def test_show_cancelled_and_unsuccessful_brief_summary_page_for_live_and_expired_framework(
-            self, data_api_client, status):
-        framework_statuses = ['live', 'expired']
+            self, data_api_client, status, framework_status):
         with self.app.app_context():
             self.login_as_buyer()
-            for framework_status in framework_statuses:
-                data_api_client.get_framework.return_value = api_stubs.framework(
-                    slug='digital-outcomes-and-specialists',
-                    status=framework_status,
-                    lots=[
-                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                    ]
-                )
-                brief_json = api_stubs.brief(status=status)
-                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-                brief_json['briefs']['specialistRole'] = 'communicationsManager'
-                brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-                data_api_client.get_brief.return_value = brief_json
-
-                res = self.client.get(
-                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
-                )
-
-                assert res.status_code == 200
-                page_html = res.get_data(as_text=True)
-                document = html.fromstring(page_html)
-
-                assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-                assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
-                    'View your published requirements',
-                    'View and shortlist suppliers',
-                    'How to shortlist suppliers',
-                    'How to evaluate suppliers',
-                    'How to award a contract',
-                    'Download the Digital Outcomes and Specialists contract',
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
                 ]
+            )
+            brief_json = api_stubs.brief(status=status)
+            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+            data_api_client.get_brief.return_value = brief_json
 
-                assert "Awarded to " not in page_html
-                assert not document.xpath('//a[contains(text(), "Delete")]')
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
+            )
+
+            assert res.status_code == 200
+            page_html = res.get_data(as_text=True)
+            document = html.fromstring(page_html)
+
+            assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
+            assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
+                'View your published requirements',
+                'View and shortlist suppliers',
+                'How to shortlist suppliers',
+                'How to evaluate suppliers',
+                'How to award a contract',
+                'Download the Digital Outcomes and Specialists contract',
+            ]
+
+            assert "Awarded to " not in page_html
+            assert not document.xpath('//a[contains(text(), "Delete")]')
 
     @pytest.mark.parametrize('framework_status', ['live', 'expired'])
     def test_show_awarded_brief_summary_page_for_live_and_expired_framework(self, data_api_client, framework_status):
-
         with self.app.app_context():
             self.login_as_buyer()
             data_api_client.get_framework.return_value = api_stubs.framework(
@@ -1874,65 +1870,65 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Awarded to 100 Percent IT Ltd" in page_html
             assert not document.xpath('//a[contains(text(), "Delete")]')
 
-    def test_show_clarification_questions_page_for_live_brief_with_no_questions(self, data_api_client):
-        framework_statuses = ['live', 'expired']
+    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
+    def test_show_clarification_questions_page_for_live_brief_with_no_questions(
+            self, data_api_client, framework_status):
         with self.app.app_context():
             self.login_as_buyer()
-            for framework_status in framework_statuses:
-                data_api_client.get_framework.return_value = api_stubs.framework(
-                    slug='digital-outcomes-and-specialists',
-                    status=framework_status,
-                    lots=[
-                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                    ]
-                )
-                brief_json = api_stubs.brief(status="live")
-                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-                brief_json['briefs']["clarificationQuestionsAreClosed"] = False
-                data_api_client.get_brief.return_value = brief_json
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            brief_json = api_stubs.brief(status="live")
+            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+            data_api_client.get_brief.return_value = brief_json
 
-                res = self.client.get(
-                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
-                )
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
+            )
 
-                assert res.status_code == 200
-                page_html = res.get_data(as_text=True)
-                assert "Supplier questions" in page_html
-                assert "No questions or answers have been published" in page_html
-                assert "Answer a supplier question" in page_html
+            assert res.status_code == 200
+            page_html = res.get_data(as_text=True)
+            assert "Supplier questions" in page_html
+            assert "No questions or answers have been published" in page_html
+            assert "Answer a supplier question" in page_html
 
-    def test_show_clarification_questions_page_for_live_brief_with_one_question(self, data_api_client):
-        framework_statuses = ['live', 'expired']
+    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
+    def test_show_clarification_questions_page_for_live_brief_with_one_question(
+            self, data_api_client, framework_status):
         with self.app.app_context():
             self.login_as_buyer()
-            for framework_status in framework_statuses:
-                data_api_client.get_framework.return_value = api_stubs.framework(
-                    slug='digital-outcomes-and-specialists',
-                    status='live',
-                    lots=[
-                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                    ]
-                )
-                brief_json = api_stubs.brief(status="live", clarification_questions=[
-                    {"question": "Why is my question a question?",
-                     "answer": "Because",
-                     "publishedAt": "2016-01-01T00:00:00.000000Z"}
-                ])
-                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-                brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-                data_api_client.get_brief.return_value = brief_json
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            brief_json = api_stubs.brief(status="live", clarification_questions=[
+                {"question": "Why is my question a question?",
+                 "answer": "Because",
+                 "publishedAt": "2016-01-01T00:00:00.000000Z"}
+            ])
+            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+            data_api_client.get_brief.return_value = brief_json
 
-                res = self.client.get(
-                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
-                )
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
+            )
 
-                assert res.status_code == 200
-                page_html = res.get_data(as_text=True)
-                assert "Supplier questions" in page_html
-                assert "Why is my question a question?" in page_html
-                assert "Because" in page_html
-                assert "Answer a supplier question" in page_html
-                assert "No questions or answers have been published" not in page_html
+            assert res.status_code == 200
+            page_html = res.get_data(as_text=True)
+            assert "Supplier questions" in page_html
+            assert "Why is my question a question?" in page_html
+            assert "Because" in page_html
+            assert "Answer a supplier question" in page_html
+            assert "No questions or answers have been published" not in page_html
 
     def test_clarification_questions_page_returns_404_if_not_live_brief(self, data_api_client):
         with self.app.app_context():


### PR DESCRIPTION
Trello ticket: https://trello.com/c/0wegHpoI/837-2-update-brief-overview-page-based-on-awarded-brief-status

Updating Brief overview page with copy changes and links as per the new design https://docs.google.com/document/d/1n-9ucQVguGvp6za2vr_VN0nciZOdysKPHDMESCkUkZs/edit#heading=h.oi57tstjuwe

Also refactored some tests to use parametrisation instead of looping through framework statuses.

~~This branch should be merged after https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/17~~ Done!

### Closed brief
![image](https://user-images.githubusercontent.com/7228605/30024175-79dc408e-916a-11e7-9c5e-e338ad13e94b.png)


### Awarded brief
![image](https://user-images.githubusercontent.com/7228605/30024202-9264bbf4-916a-11e7-97e1-be437ed708cc.png)

### Unsuccessful
![image](https://user-images.githubusercontent.com/7228605/30024266-de946e52-916a-11e7-8245-803b8767316e.png)


### Cancelled
![image](https://user-images.githubusercontent.com/7228605/30024276-f6cd5b96-916a-11e7-988e-a34a1a00a3e8.png)
