### PR TITLE
Fix create user external view URL to use the user-frontend endpoint

### DIFF
--- a/app/external/views/external.py
+++ b/app/external/views/external.py
@@ -8,7 +8,7 @@ def get_brief_by_id(framework_framework, brief_id):
     raise NotImplementedError()
 
 
-@external.route('/create-user/<string:encoded_token>')
+@external.route('/user/create/<string:encoded_token>')
 def create_user(encoded_token):
     raise NotImplementedError()
 


### PR DESCRIPTION
User creation was moved from the buyer-frontend to user-frontend, so
we need to update the external view URL.