### PR TITLE
Temporary fix - Style h2 in section-description

### DIFF
--- a/app/assets/scss/_brief_submission.scss
+++ b/app/assets/scss/_brief_submission.scss
@@ -77,6 +77,11 @@ ol.steps {
 }
 
 .section-description {
-   @extend %markdown-description;
-   padding-bottom: 30px;
+  @extend %markdown-description;
+  padding-bottom: 30px;
+  h2 {
+    @extend %heading-small;
+    margin-bottom: -5px;
+  }
 }
+


### PR DESCRIPTION
This is a temporary fix for the h2s within .section-description which is only in use on the briefs app, ideally any styling that needs to exist should be reviewed and moved to the frontend toolkit.

Before:
<img width="1194" alt="before" src="https://user-images.githubusercontent.com/3798032/30071658-6fcf455a-925f-11e7-82fe-e0347730f7c4.png">

After:
<img width="1199" alt="after" src="https://user-images.githubusercontent.com/3798032/30071659-6fd3fe1a-925f-11e7-89c0-15de25015f4f.png">

