### PR TITLE
Redirect to DOS Dashboard

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -484,6 +484,10 @@ def award_brief_details(framework_slug, lot_slug, brief_id, brief_response_id):
             ), 400
 
         flash({"updated-brief": brief.get("title")})
+
+        if flask_featureflags.is_active('DIRECT_AWARD_PROJECTS'):
+            return redirect(url_for(".buyer_dos_requirements"))
+
         return redirect(url_for(".buyer_dashboard"))
 
     return render_template(
@@ -818,6 +822,10 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
 
     data_api_client.delete_brief(brief_id, current_user.email_address)
     flash({"requirements_deleted": brief.get("title")})
+
+    if flask_featureflags.is_active('DIRECT_AWARD_PROJECTS'):
+        return redirect(url_for(".buyer_dos_requirements"))
+
     return redirect(url_for('.buyer_dashboard'))
 
 

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1599,7 +1599,7 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
 
             assert res.status_code == 302
             assert data_api_client.delete_brief.called
-            assert res.location == "http://localhost/buyers"
+            assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
 
     def test_404_if_framework_is_not_live_or_expired(self, data_api_client):
         for framework_status in ['coming', 'open', 'pending', 'standstill']:
@@ -3535,7 +3535,7 @@ class TestAwardBriefDetails(BaseApplicationTest):
                 updated_by="buyer@email.com"
             )
             assert res.status_code == 302
-            assert res.location == "http://localhost/buyers"
+            assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
             self.assert_flashes("updated-brief")
 
     @mock.patch('app.main.views.buyers.is_brief_correct')


### PR DESCRIPTION
## Summary
We've moved the requirements dashboard to another URL but didn't update where the 'award a brief' and 'delete a requirement' flows end. These need to be updated to point to the correct dashboard because the briefs-frontend uses old-style flash messages, and the buyer-frontend uses new-style (frontend-toolkit) flash messages. The buyer-frontend doesn't know how to render the flash messages generated by the briefs-frontend and the functional tests fail.

Also it feels like awarding a brief/deleting a requirement intend to go back to the DOS dashboard, so this feels like the right change regardless.

However, if we don't want to make these go straight to the DOS dashboard, we could simply have extra steps in the functional tests to click on 'View your requirements' from the dual buyers dashboard, and the flash messages should then be picked up and displayed. Open to input on which we prefer.