### PR TITLE
818 add no journey to the award flow

### DIFF
--- a/app/main/forms/award_or_cancel.py
+++ b/app/main/forms/award_or_cancel.py
@@ -1,0 +1,22 @@
+from flask.ext.wtf import Form
+from wtforms import RadioField, validators
+
+
+class AwardOrCancelBriefForm(Form):
+    """Form for the buyer to tell us whether they want to award or cancel the requirement
+    """
+    choices = [
+        ('yes', 'Yes'),
+        ('no', 'No'),
+        ('back', 'We are still evaluating suppliers'),
+    ]
+    award_or_cancel_decision = RadioField(
+        validators=[validators.InputRequired(message='You need to answer this question.')],
+        choices=choices
+    )
+
+    def __init__(self, brief, *args, **kwargs):
+        super(AwardOrCancelBriefForm, self).__init__(*args, **kwargs)
+        brief_name = brief.get('title', brief.get('lotName', ''))
+        self.award_or_cancel_decision.label.text = "Have you awarded a contract for {}?".format(brief_name)
+        self.award_or_cancel_decision.toolkit_macro_options = [{'value': i[0], 'label': i[1]} for i in self.choices]

--- a/app/main/forms/awards.py
+++ b/app/main/forms/awards.py
@@ -12,18 +12,16 @@ class AwardedBriefResponseForm(Form):
         coerce=int
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, brief_responses, *args, **kwargs):
         """
-            Requires extra keyword arguments:
+            Requires extra argument:
              - `brief_responses` - list of BriefResponses for the multiple choice
         """
         super(AwardedBriefResponseForm, self).__init__(*args, **kwargs)
 
-        # popping this kwarg so we don't risk it getting fed to wtforms default implementation which might use it
-        # as a data field if there were a name collision
         brief_responses = list(
             sorted(
-                [{'id': b['id'], 'name': b['supplierName']} for b in kwargs.pop("brief_responses", [])],
+                [{'id': b['id'], 'name': b['supplierName']} for b in brief_responses],
                 key=lambda x: x['name']
             )
         )

--- a/app/main/forms/cancel.py
+++ b/app/main/forms/cancel.py
@@ -3,7 +3,7 @@ from wtforms import RadioField, validators
 
 
 class CancelBriefForm(Form):
-    """Form for the buyer to tell us why they cancel the requirement
+    """Form for the buyer to tell us why they are cancelling the requirement
     """
     choices = [
         ('cancel', 'The requirement has been cancelled'),
@@ -14,9 +14,8 @@ class CancelBriefForm(Form):
         choices=choices
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, brief, label_text, *args, **kwargs):
         super(CancelBriefForm, self).__init__(*args, **kwargs)
-        brief = kwargs.pop('brief')
         brief_name = brief.get('title', brief.get('lotName', ''))
-        self.cancel_reason.label.text = "Why do you need to cancel {}?".format(brief_name)
+        self.cancel_reason.label.text = label_text.format(brief_name)
         self.cancel_reason.toolkit_macro_options = [{'value': i[0], 'label': i[1]} for i in self.choices]

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -495,11 +495,22 @@ def award_or_cancel_brief(framework_slug, lot_slug, brief_id):
                 # We should never get here as the form validates the answers against the available choices.
                 abort(500, "Unexpected answer to award or cancel brief")
 
+    breadcrumbs = get_briefs_breadcrumbs([{
+        "label": brief['title'],
+        "link": url_for(
+            ".view_brief_overview",
+            framework_slug = brief['frameworkSlug'],
+            lot_slug = brief['lotSlug'],
+            brief_id = brief['id']
+        )
+    }])
+
     return render_template(
         "buyers/award_or_cancel_brief.html",
         brief=brief,
         form=form or AwardOrCancelBriefForm(brief),
         errors=errors,
+        breadcrumbs=breadcrumbs
     ), 200 if not errors else 400
 
 

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -600,8 +600,8 @@ def award_brief(framework_slug, lot_slug, brief_id):
 def cancel_brief(framework_slug, lot_slug, brief_id):
     form = None
     errors = {}
-    end_point = request.endpoint.strip(request.blueprint + '.')
-    label_text = "Why didn't you award a contract for {}?" if end_point == 'cancel_award_brief' else None
+    award_flow = request.endpoint.strip(request.blueprint + '.') == 'cancel_award_brief'
+
     get_framework_and_lot(
         framework_slug,
         lot_slug,
@@ -678,6 +678,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
         form=form or CancelBriefForm(brief, label_text),
         errors=errors,
         breadcrumbs=breadcrumbs,
+        previous_page_url=previous_page_url
     ), 200 if not errors else 400
 
 

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -545,7 +545,7 @@ def award_brief(framework_slug, lot_slug, brief_id):
         )
 
     if request.method == "POST":
-        form = AwardedBriefResponseForm(request.form, brief_responses=brief_responses)
+        form = AwardedBriefResponseForm(brief_responses, request.form)
         if not form.validate_on_submit():
             form_errors = [{'question': form[key].label.text, 'input_name': key} for key in form.errors]
             return render_template(
@@ -576,7 +576,7 @@ def award_brief(framework_slug, lot_slug, brief_id):
                 )
             )
 
-    form = AwardedBriefResponseForm(brief_responses=brief_responses)
+    form = AwardedBriefResponseForm(brief_responses)
     pending_brief_responses = list(filter(lambda x: x.get('awardDetails', {}).get('pending'), brief_responses))
     form['brief_response'].data = pending_brief_responses[0]["id"] if pending_brief_responses else None
 
@@ -588,10 +588,20 @@ def award_brief(framework_slug, lot_slug, brief_id):
     ), 200
 
 
-@main.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/cancel', methods=['GET', 'POST'])
+@main.route(
+    '/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/cancel',
+    methods=['GET', 'POST'],
+)
+@main.route(
+    '/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/cancel-award',
+    methods=['GET', 'POST'],
+    endpoint="cancel_award_brief"
+)
 def cancel_brief(framework_slug, lot_slug, brief_id):
     form = None
     errors = {}
+    end_point = request.endpoint.strip(request.blueprint + '.')
+    label_text = "Why didn't you award a contract for {}?" if end_point == 'cancel_award_brief' else None
     get_framework_and_lot(
         framework_slug,
         lot_slug,
@@ -605,8 +615,25 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
     if brief["status"] != "closed":
         abort(404)
 
+    if award_flow:
+        label_text = "Why didn't you award a contract for {}?"
+        previous_page_url = url_for(
+            '.award_or_cancel_brief',
+            framework_slug=brief['frameworkSlug'],
+            lot_slug=brief['lotSlug'],
+            brief_id=brief['id']
+        )
+    else:
+        # Use default label text
+        label_text = 'Why do you need to cancel {}?'
+        previous_page_url = url_for(
+            '.view_brief_overview',
+            framework_slug=brief['frameworkSlug'],
+            lot_slug=brief['lotSlug'],
+            brief_id=brief['id']
+        )
     if request.method == "POST":
-        form = CancelBriefForm(request.form, brief=brief)
+        form = CancelBriefForm(brief, label_text, request.form)
         if not form.validate_on_submit():
             errors = {
                 key: {'question': form[key].label.text, 'input_name': key, 'message': form[key].errors[0]}
@@ -648,7 +675,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
     return render_template(
         "buyers/cancel_brief.html",
         brief=brief,
-        form=form or CancelBriefForm(brief=brief),
+        form=form or CancelBriefForm(brief, label_text),
         errors=errors,
         breadcrumbs=breadcrumbs,
     ), 200 if not errors else 400

--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -50,6 +50,13 @@
                       {% endwith %}
                     {% endblock %}
               </form>
+              {%
+                with
+                url=url_for('.award_or_cancel_brief', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'], brief_id=brief['id']),
+                text="Previous page"
+              %}
+                {% include "toolkit/secondary-action-link.html" %}
+              {% endwith %}
           </div>
     </div>
 </div>

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -52,7 +52,7 @@
       {%
           with
           url=url_for(".award_brief", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-          text="Back to previous page"
+          text="Previous page"
       %}
           {% include "toolkit/secondary-action-link.html" %}
       {% endwith %}

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -1,0 +1,75 @@
+{% extends "_base_page.html" %}
+
+{% import "toolkit/forms/macros/forms.html" as forms %}
+
+{% block page_title %}{{ brief.title or brief.lotName }} – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for(".buyer_dashboard"),
+        "label": "Your account"
+      },
+      {
+        "link": url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+        "label": brief.title
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  {% if errors %}
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
+  {% endif %}
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <div class="single-question-page">
+
+        {% with
+        heading = form.award_or_cancel_decision.label.text,
+        smaller = True
+        %}
+          {% include 'toolkit/page-heading.html' %}
+        {% endwith %}
+
+          <p class="question-advice">The information you provide will be shown on the opportunity. This makes the buying process more transparent.</p>
+          <form method="POST" action="{{ url_for('.award_or_cancel_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            {%
+                  with
+                  name = "award_or_cancel_decision",
+                  question = form.award_or_cancel_decision.label.text,
+                  type = "radio",
+                  options = form.award_or_cancel_decision.toolkit_macro_options,
+                  value = form.award_or_cancel_decision.data,
+                  error = errors.get('award_or_cancel_decision', {}).get('message', None)
+                  %}
+              {% include "toolkit/forms/selection-buttons.html" %}
+          {% endwith %}
+
+
+          {% block save_button %}
+            {%
+              with
+              label="Save and continue",
+              name="submit",
+              type="save"
+            %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+        {% endblock %}
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -5,22 +5,7 @@
 {% block page_title %}{{ brief.title or brief.lotName }} – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
-      {
-        "link": "/",
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": url_for(".buyer_dashboard"),
-        "label": "Your account"
-      },
-      {
-        "link": url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-        "label": brief.title
-      }
-    ]
-  %}
+  {% with items = breadcrumbs %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
 {% endblock %}

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -205,7 +205,7 @@
                   'allowed_statuses': ['draft', 'live', 'closed']
                 },
                 {
-                  'href': url_for(".award_brief", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  'href': url_for(".award_or_cancel_brief", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': "Let suppliers know the outcome",
                   'allowed_statuses': ['closed']
                 }

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -23,7 +23,7 @@
       <div class="single-question-page">
 
         {% with
-        heading = "Why do you need to cancel {}?".format(brief.get('title', brief['lotName'])),
+        heading = form.cancel_reason.label.text,
         smaller = True
         %}
           {% include 'toolkit/page-heading.html' %}
@@ -34,7 +34,7 @@
           {%
             with
             name = "cancel_reason",
-            question = "Why do you need to cancel {}?".format(brief.get('title', brief['lotName'])),
+            question = form.cancel_reason.label.text,
             type = "radio",
             options = form.cancel_reason.toolkit_macro_options,
             value = form.cancel_reason.data,

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -56,6 +56,14 @@
           {% endwith %}
         {% endblock %}
         </form>
+
+        {%
+          with
+          url=previous_page_url,
+          text="Previous page"
+        %}
+          {% include "toolkit/secondary-action-link.html" %}
+        {% endwith %}
       </div>
     </div>
   </div>

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -29,7 +29,7 @@
           {% include 'toolkit/page-heading.html' %}
         {% endwith %}
 
-        <form method="POST" action="{{ url_for('.cancel_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
+        <form method="POST" action="{{ url_for(request.endpoint, framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {%
             with

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -137,7 +137,7 @@
             <div class="padding-bottom-small">
                 <p><a href="{{ url_for('.view_brief_responses', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">View responses</a></p>
                 {% if item.status == "closed" %}
-                    <p><a class="award-contract-link" href="{{ url_for('.award_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
+                    <p><a class="award-contract-link" href="{{ url_for('.award_or_cancel_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
                 {% endif %}
             </div>
             <form method="post" action="{{ url_for('.copy_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -137,7 +137,7 @@
             <div class="padding-bottom-small">
                 <p><a href="{{ url_for('.view_brief_responses', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">View responses</a></p>
                 {% if item.status == "closed" %}
-                    <p><a class="award-contract-link" href="{{ url_for('.award_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Tell us who won this contract</a></p>
+                    <p><a class="award-contract-link" href="{{ url_for('.award_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
                 {% endif %}
             </div>
             <form method="post" action="{{ url_for('.copy_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -144,7 +144,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert closed_row_cells[2].xpath('.//a/@href')[0] == \
             '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/22/responses'
 
-        assert closed_row_cells[2].xpath('.//a')[1].text_content() == "Tell us who won this contract"
+        assert closed_row_cells[2].xpath('.//a')[1].text_content() == "Let suppliers know the outcome"
         assert closed_row_cells[2].xpath('.//a/@href')[1] == \
             '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/22/award-contract'
 
@@ -163,7 +163,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert withdrawn_row.xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert withdrawn_row_cells[1] == "Withdrawn"
         assert "View responses" not in withdrawn_row_cells[2]
-        assert "Tell us who won this contract" not in withdrawn_row_cells[2]
+        assert "Let suppliers know the outcome" not in withdrawn_row_cells[2]
 
     def test_closed_briefs_section_with_awarded_brief(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock
@@ -180,7 +180,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert awarded_row.xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert awarded_row_cells[1] == "Friday 19 February 2016"
         assert "View responses" not in awarded_row_cells[2]
-        assert "Tell us who won this contract" not in awarded_row_cells[2]
+        assert "Let suppliers know the outcome" not in awarded_row_cells[2]
 
     def test_closed_briefs_section_with_cancelled_brief(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock
@@ -197,7 +197,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert cancelled_row.xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert cancelled_row_cells[1] == "Wednesday 17 February 2016"
         assert "View responses" not in cancelled_row_cells[2]
-        assert "Tell us who won this contract" not in cancelled_row_cells[2]
+        assert "Let suppliers know the outcome" not in cancelled_row_cells[2]
 
     def test_closed_briefs_section_with_unsuccessful_brief(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock
@@ -214,7 +214,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert unsuccessful_row.xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert unsuccessful_row_cells[1] == "Tuesday 16 February 2016"
         assert "View responses" not in unsuccessful_row_cells[2]
-        assert "Tell us who won this contract" not in unsuccessful_row_cells[2]
+        assert "Let suppliers know the outcome" not in unsuccessful_row_cells[2]
 
     def test_flash_message_shown_if_brief_has_just_been_updated(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -146,7 +146,7 @@ class TestBuyerDashboard(BaseApplicationTest):
 
         assert closed_row_cells[2].xpath('.//a')[1].text_content() == "Let suppliers know the outcome"
         assert closed_row_cells[2].xpath('.//a/@href')[1] == \
-            '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/22/award-contract'
+            '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/22/award'
 
     def test_closed_briefs_section_with_withdrawn_brief(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock


### PR DESCRIPTION
https://trello.com/c/LcbXbFx7/818-3-add-no-journey-to-the-award-flow

This PR joins together the award flow and cancel flow with an 'award or cancel' step:

![award_or_cancel_flow](https://user-images.githubusercontent.com/3469840/30471552-127a0fe0-99f1-11e7-95b0-823926696cee.png)

It adds a new url to the cancel view '/award-cancel'. When accessing the view through this url the form text on the page is updated to read 'Why didn’t you award a contract for [brief name]?' instead of the default 'Why do you need to cancel [brief name]?' detailed here: https://docs.google.com/document/d/1n-9ucQVguGvp6za2vr_VN0nciZOdysKPHDMESCkUkZs/edit#heading=h.l4xho8gj18u3
This comes with associated tweaks to the cancel brief form and view.

It also adds a completely new form, view and template (https://award-prototype.cloudapps.digital/award/status/award?opportunity_id=1):
![newform](https://user-images.githubusercontent.com/3469840/30471633-605928fe-99f1-11e7-94d4-da0007f3e130.png)

The view has 4 'routes'. GET shows the form, POST with 'yes' takes you to the form to pick a supplier you awarded your brief to, POST with 'no' takes you to the cancel flow through the new url asking 'why you didn't award',  POST with 'back' returns you to the DOS requirements overview.


There is quite a bit or repetition in the form files and the view and test files. Refactoring this in this PR would obscure the new logic and tests and is somewhat out of scope of this PR. I've raised a tech debt ticket to addres this at a future date:
https://trello.com/c/xTjixqZX/195-reduce-repetition-of-code-in-app-main-forms-app-main-views-tests-main-testviews-in-briefs-frontend