### PR TITLE
Updated content for MVP

### DIFF
--- a/app/main/helpers/buyers_helpers.py
+++ b/app/main/helpers/buyers_helpers.py
@@ -93,7 +93,7 @@ def get_briefs_breadcrumbs(additional_breadcrumbs=[]):
         },
         {
             "link": url_for("buyers.buyer_dos_requirements"),
-            "label": "Your requirements"
+            "label": "Requirements"
         }
     ]
 

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -36,7 +36,7 @@
       {% endif %}
     </p>
   
-    <h2 class="heading-xmedium">Digital outcomes, specialists and user research</h2>
+    <h2 class="heading-xmedium">Digital outcomes, specialists and user research participants</h2>
     <p>
       {% if user_briefs_total %}
         <a href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>  

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -260,7 +260,7 @@ class BaseApplicationTest(object):
         breadcrumbs_we_expect = [
             ('Digital Marketplace', '/'),
             ('Your account', '/buyers'),
-            ('Your requirements', '/buyers/requirements/digital-outcomes-and-specialists'),
+            ('Requirements', '/buyers/requirements/digital-outcomes-and-specialists'),
         ]
         if extra_breadcrumbs:
             breadcrumbs_we_expect.extend(extra_breadcrumbs)


### PR DESCRIPTION
Updated content for MVP: added missing word `participants` to the DOS heading.

Ticket 729: https://trello.com/c/xAmyH5CE/729-content-check-and-update-buyer-account-page

Updated the breadcrumb for the DOS requirements page.

Ticket 731: https://trello.com/c/03kbaHWk/731-content-dos-overview-page