### PR TITLE
Bump version of Frameworks repo to 8.14.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#24.1.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.12.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.14.1"
   }
 }

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -3559,7 +3559,7 @@ class TestAwardBriefDetails(BaseApplicationTest):
             error_spans = document.xpath('//span[@class="validation-message"]')
             assert self._strip_whitespace(error_spans[0].text_content()) == "Youranswermustbeavaliddate."
             assert self._strip_whitespace(error_spans[1].text_content()) == \
-                "Valuemustbeinnumbersanddecimalpointsonly,forexample99.95."
+                "Valuemustbeinnumbersanddecimalpointsonly,forexample9900.95for9900poundsand95pence."
 
             # Prefilled form input
             assert document.xpath('//input[@id="input-awardedContractValue"]/@value')[0] == "incorrect"


### PR DESCRIPTION
This was done to include updated content for award flow.

Trello ticket: https://trello.com/c/zNCy9jwG/869-change-help-text-for-contract-value