### PR TITLE
Award email landing page and GA events

### DIFF
--- a/app/assets/javascripts/analytics/_events.js
+++ b/app/assets/javascripts/analytics/_events.js
@@ -97,8 +97,31 @@
         });
       }
     },
+    'awardDetailsSubmitButtonClick': function () {
+      var currentURL = GOVUK.GDM.analytics.location.pathname();
+
+      // check we're on the award details page
+      if (currentURL.match('\/buyers\/frameworks\/[a-z0-9-]+\/requirements\/[a-z0-9-]+\/[0-9]+\/award\/[0-9]+\/contract-details')) {
+        GOVUK.analytics.trackEvent('Buyer Award', 'Awarded');
+      }
+
+    },
+    'cancelAwardSubmitButtonClick': function () {
+      var currentURL = GOVUK.GDM.analytics.location.pathname();
+
+      // check we're on the 'why did you cancel' page
+      if (currentURL.match('\/buyers\/frameworks\/[a-z0-9-]+\/requirements\/[a-z0-9-]+\/[0-9]+\/cancel-award')) {
+        var selectedCancelReason = $("input[name='cancel_reason']:checked").val();
+        if (selectedCancelReason) {
+          GOVUK.analytics.trackEvent('Buyer Award', 'Not-awarded', {'label': selectedCancelReason});
+        }
+      }
+
+    },
     'init': function () {
       $('body').on('click', 'a', this.supplierListDownload)
+        .on('click', 'input[type=submit]', this.awardDetailsSubmitButtonClick)
+        .on('click', 'input[type=submit]', this.cancelAwardSubmitButtonClick);
     }
   };
 })(window, window.GOVUK);

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -19,10 +19,20 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <div class="single-question-page">
-
+        {% if already_awarded %}
+          {% with
+                heading = "Requirements already updated for {}".format(brief.title),
+                smaller = true
+          %}
+            {% include 'toolkit/page-heading.html' %}
+          {% endwith %}
+            <p>
+              <a href="{{ url_for('external.get_brief_by_id', framework_framework=brief.frameworkFramework, brief_id=brief.id) }}">View the outcome of the requirements</a>
+            </p>
+      {% else %}
         {% with
-        heading = form.award_or_cancel_decision.label.text,
-        smaller = True
+          heading = form.award_or_cancel_decision.label.text,
+          smaller = True
         %}
           {% include 'toolkit/page-heading.html' %}
         {% endwith %}
@@ -40,20 +50,20 @@
                   error = errors.get('award_or_cancel_decision', {}).get('message', None)
                   %}
               {% include "toolkit/forms/selection-buttons.html" %}
-          {% endwith %}
+            {% endwith %}
 
-
-          {% block save_button %}
-            {%
-              with
-              label="Save and continue",
-              name="submit",
-              type="save"
-            %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
-        {% endblock %}
-        </form>
+            {% block save_button %}
+              {%
+                with
+                label="Save and continue",
+                name="submit",
+                type="save"
+              %}
+                {% include "toolkit/button.html" %}
+              {% endwith %}
+            {% endblock %}
+          </form>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Ticket: https://trello.com/c/poIdAQc0/751-3-create-script-to-send-emails-to-buyers-with-recently-closed-briefs-at-scheduled-intervals

- Trigger GA events for submitting the award form and the cancelled form (see https://docs.google.com/spreadsheets/d/10svF3zT1_DkRSBIlmYZAOBwM7Om-jENxZnmwMZDhqDA/edit#gid=0 for the expected event values)
   - AWARDED event POST url: https://www.google-analytics.com/collect?t=event&dl=http%3A%2F%2Flocalhost%2Fbuyers%2Fframeworks%2Fdigital-outcomes-and-specialists-2%2Frequirements%2Fdigital-specialists%2F5203%2Faward%2F29360%2Fcontract-details&dt=Kat%20python2%20copy%20%E2%80%93%20Digital%20Marketplace&ec=Buyer%20Award&ea=Awarded
   - CANCELLED event POST url: https://www.google-analytics.com/collect?t=event&dl=http%3A%2F%2Flocalhost%2Fbuyers%2Fframeworks%2Fdigital-outcomes-and-specialists-2%2Frequirements%2Fdigital-specialists%2F5203%2Fcancel-award&dt=Kat%20python2%20copy%20%E2%80%93%20Digital%20Marketplace&ec=Buyer%20Award&ea=Not-awarded&el=cancel
   - UNSUCCESSFUL event POST url: https://www.google-analytics.com/collect?t=event&dl=http%3A%2F%2Flocalhost%2Fbuyers%2Fframeworks%2Fdigital-outcomes-and-specialists-2%2Frequirements%2Fdigital-specialists%2F5203%2Fcancel-award&dt=Kat%20python2%20copy%20%E2%80%93%20Digital%20Marketplace&ec=Buyer%20Award&ea=Not-awarded&el=unsuccessful
- Changed the Awarded Yes/No page to show a message instead of a 404, if the brief has already been awarded. 
- Strengthened some test scenarios to cover different Brief statuses.