### PR TITLE
Move buyer user creation emails to notify

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,20 +33,19 @@ class Config(object):
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
     DM_MANDRILL_API_KEY = None
+    DM_NOTIFY_API_KEY = None
+
+    NOTIFY_TEMPLATES = {
+        'create_user_account': '1d1e38a6-744a-4d5a-84af-aefccde70a6c',
+    }
 
     # This is just a placeholder
     ES_ENABLED = True
 
     DEBUG = False
 
-    RESET_PASSWORD_EMAIL_NAME = 'Digital Marketplace Admin'
-    RESET_PASSWORD_EMAIL_FROM = 'enquiries@digitalmarketplace.service.gov.uk'
-    RESET_PASSWORD_EMAIL_SUBJECT = 'Reset your Digital Marketplace password'
-
-    CREATE_USER_SUBJECT = 'Create your Digital Marketplace account'
     SECRET_KEY = None
     SHARED_EMAIL_KEY = None
-    RESET_PASSWORD_SALT = 'ResetPasswordSalt'
     INVITE_EMAIL_SALT = 'InviteEmailSalt'
 
     STATIC_URL_PATH = '/buyers/static'
@@ -99,6 +98,7 @@ class Test(Config):
     DM_DATA_API_AUTH_TOKEN = "myToken"
 
     DM_MANDRILL_API_KEY = 'MANDRILL'
+    DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
     SHARED_EMAIL_KEY = "KEY"
     SECRET_KEY = "KEY"
 
@@ -115,6 +115,7 @@ class Development(Config):
     DM_DATA_API_AUTH_TOKEN = "myToken"
 
     DM_MANDRILL_API_KEY = "not_a_real_key"
+    DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
     SECRET_KEY = "verySecretKey"
     SHARED_EMAIL_KEY = "very_secret"
 
@@ -137,9 +138,18 @@ class Preview(Live):
 class Staging(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-07')
 
+    NOTIFY_TEMPLATES = {
+        'create_user_account': '84f5d812-df9d-4ab8-804a-06f64f5abd30',
+    }
+
+    # Check we didn't forget any live template IDs
+    assert NOTIFY_TEMPLATES.keys() == Config.NOTIFY_TEMPLATES.keys()
+
 
 class Production(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-08')
+
+    NOTIFY_TEMPLATES = Staging.NOTIFY_TEMPLATES
 
 
 configs = {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.4.0#egg=digitalmarketplace-utils==28.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.1.0#egg=digitalmarketplace-apiclient==10.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.4.0#egg=digitalmarketplace-utils==28.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.1.0#egg=digitalmarketplace-apiclient==10.3.0
 
@@ -16,7 +16,7 @@ asn1crypto==0.22.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
-cffi==1.10.0
+cffi==1.11.0
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0

--- a/tests/create_buyers/views/test_create_buyers.py
+++ b/tests/create_buyers/views/test_create_buyers.py
@@ -13,9 +13,9 @@ class TestBuyersCreation(BaseApplicationTest):
         assert res.status_code == 200
         assert 'Create a buyer account' in res.get_data(as_text=True)
 
-    @mock.patch('app.create_buyer.views.create_buyer.send_email')
+    @mock.patch('app.create_buyer.views.create_buyer.InviteUser')
     @mock.patch('app.create_buyer.views.create_buyer.data_api_client')
-    def test_should_be_able_to_submit_valid_email_address(self, data_api_client, send_email):
+    def test_should_be_able_to_submit_valid_email_address(self, data_api_client, InviteUser):
         res = self.client.post(
             '/buyers/create',
             data={'email_address': 'valid@test.gov.uk'},
@@ -31,9 +31,9 @@ class TestBuyersCreation(BaseApplicationTest):
         )
         assert res.status_code == 200
 
-    @mock.patch('app.create_buyer.views.create_buyer.send_email')
+    @mock.patch('app.create_buyer.views.create_buyer.InviteUser')
     @mock.patch('app.create_buyer.views.create_buyer.data_api_client')
-    def test_creating_account_doesnt_affect_csrf_token(self, data_api_client, send_email):
+    def test_creating_account_doesnt_affect_csrf_token(self, data_api_client, InviteUser):
         with self.client as c:
             c.get(
                 '/buyers/create',
@@ -94,22 +94,42 @@ class TestBuyersCreation(BaseApplicationTest):
         assert "You must use a public sector email address" in data
         assert "The email you used doesn't belong to a recognised public sector domain." in data
 
+    @mock.patch('app.create_buyer.views.create_buyer.InviteUser')
     @mock.patch('app.create_buyer.views.create_buyer.data_api_client')
-    @mock.patch('app.create_buyer.views.create_buyer.send_email')
-    def test_should_503_if_email_fails_to_send(self, send_email, data_api_client):
-        data_api_client.is_email_address_with_valid_buyer_domain.return_value = True
-        send_email.side_effect = EmailError("Arrrgh")
+    def test_should_send_mail_with_correct_attributes(self, data_api_client, InviteUser):
+        send_invite_email_mock = mock.Mock(token='invite-token')
+        InviteUser.return_value = send_invite_email_mock
+
         res = self.client.post(
             '/buyers/create',
             data={'email_address': 'valid@test.gov.uk'},
-            follow_redirects=True
+            follow_redirects=False
         )
-        assert res.status_code == 503
-        assert USER_CREATION_EMAIL_ERROR in res.get_data(as_text=True)
 
-    @mock.patch('app.create_buyer.views.create_buyer.send_email')
+        InviteUser.assert_called_once_with(
+            {'role': 'buyer', 'email_address': 'valid@test.gov.uk'}
+        )
+        send_invite_email_mock.send_invite_email.assert_called_once_with('http://localhost/user/create/invite-token')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/buyers/create-your-account-complete'
+
+
+    @mock.patch('dmutils.email.invite_user.DMNotifyClient')
     @mock.patch('app.create_buyer.views.create_buyer.data_api_client')
-    def test_should_create_audit_event_when_email_sent(self, data_api_client, send_email):
+    def test_email_address_is_correctly_stored_in_session(self, data_api_client, DMNotifyClient):
+        with self.client as c:
+            c.post(
+                '/buyers/create',
+                data={'email_address': 'valid@test.gov.uk'},
+                follow_redirects=False
+            )
+
+            assert session.get('email_sent_to') == 'valid@test.gov.uk'
+
+
+    @mock.patch('app.create_buyer.views.create_buyer.InviteUser')
+    @mock.patch('app.create_buyer.views.create_buyer.data_api_client')
+    def test_should_create_audit_event_when_email_sent(self, data_api_client, InviteUser):
         res = self.client.post(
             '/buyers/create',
             data={'email_address': 'valid@test.gov.uk'},


### PR DESCRIPTION
Tests won't pass util this PR on utils goes in: [https://github.com/alphagov/digitalmarketplace-utils/pull/333](https://github.com/alphagov/digitalmarketplace-utils/pull/333)

Part of this ticket: https://trello.com/c/HlSz9QZZ

Sending user invite emails for buyers and suppliers is really similar.
Whilst moving out email sending to Notify it makes sense to combine the
similar code and pull it back to a shared place, utils.

This commit removes the Mandrill functionality and imports Notify
functionality from utils.
