### PR TITLE
Flake8 extra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test-requirements:
 	    || { echo "requirements.txt is up to date"; exit 0; }
 
 .PHONY: test-flake8
-test-pep8: virtualenv
+test-flake8: virtualenv
 	${VIRTUALENV_ROOT}/bin/flake8 .
 
 .PHONY: test-python

--- a/app/create_buyer/views/create_buyer.py
+++ b/app/create_buyer/views/create_buyer.py
@@ -1,4 +1,4 @@
-from flask import current_app, render_template, url_for, abort, redirect, session, Blueprint
+from flask import current_app, render_template, url_for, redirect, session, Blueprint
 
 from dmapiclient.audit import AuditTypes
 from dmutils.email import send_user_account_email

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -500,9 +500,9 @@ def award_or_cancel_brief(framework_slug, lot_slug, brief_id):
         "label": brief['title'],
         "link": url_for(
             ".view_brief_overview",
-            framework_slug = brief['frameworkSlug'],
-            lot_slug = brief['lotSlug'],
-            brief_id = brief['id']
+            framework_slug=brief['frameworkSlug'],
+            lot_slug=brief['lotSlug'],
+            brief_id=brief['id']
         )
     }])
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ watchdog==0.8.3
 freezegun==0.3.4
 
 coverage==3.7.1
-flake8==3.4.1
+flake8==2.6.2
 flake8-putty==0.4.0
 pytest-cov==2.2.0
 python-coveralls==2.5.0

--- a/tests/create_buyers/views/test_create_buyers.py
+++ b/tests/create_buyers/views/test_create_buyers.py
@@ -1,6 +1,5 @@
 import mock
 from flask import session, current_app
-from dmutils.email.exceptions import EmailError
 from dmapiclient.audit import AuditTypes
 from ...helpers import BaseApplicationTest
 
@@ -114,7 +113,6 @@ class TestBuyersCreation(BaseApplicationTest):
             assert res.status_code == 302
             assert res.location == 'http://localhost/buyers/create-your-account-complete'
 
-
     @mock.patch('dmutils.email.user_account_email.DMNotifyClient')
     @mock.patch('app.create_buyer.views.create_buyer.data_api_client')
     def test_email_address_is_correctly_stored_in_session(self, data_api_client, DMNotifyClient):
@@ -126,7 +124,6 @@ class TestBuyersCreation(BaseApplicationTest):
             )
 
             assert session.get('email_sent_to') == 'valid@test.gov.uk'
-
 
     @mock.patch('app.create_buyer.views.create_buyer.send_user_account_email')
     @mock.patch('app.create_buyer.views.create_buyer.data_api_client')

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -3723,12 +3723,8 @@ class TestCancelBrief(BaseApplicationTest):
     def test_that_no_option_chosen_does_not_trigger_update(self):
         res = self.client.post(self.url.format(brief_id=123))
 
-        document = html.fromstring(res.get_data(as_text=True))
-        validation_message = document.xpath('//span[@class="validation-message"]')[0].text_content()
-
         assert res.status_code == 400
         self.data_api_client.cancel_brief.assert_not_called()
-
 
     def test_cancel_triggers_cancel_brief(self):
         res = self.client.post(
@@ -3880,7 +3876,6 @@ class TestAwardOrCancelBrief(BaseApplicationTest):
         self.login_as_buyer()
         res = self.client.post(self.url.format(brief_id=self.brief['id']), data={'award_or_cancel_decision': 'yes'})
 
-        redirect_text = html.fromstring(res.get_data(as_text=True)).text_content().strip()
         expected_url = (
             'http://localhost/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/'
             'digital-outcomes/{}/award-contract'


### PR DESCRIPTION
`flake8-putty` is not yet compatible with putty > v3.0.0 so we're pinning the version for now.
https://github.com/jayvdb/flake8-putty/issues/14

This PR pins the version lower, updates the make command and applys some flake8 fixes.