### PR TITLE
Update intro text for digital specialists and digital outcomes

### DIFF
--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -40,10 +40,24 @@
     <div class="column-two-thirds large-paragraph">
         <div class="marketplace-paragraph">
             <p>
+                 {% set digital_specialists_intro %}
+                        You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.
+                    </p> <p>
+                        You need to write 'requirements' to describe the work and tell suppliers to provide a specialist. The specialist can’t work for you outside the scope of your written requirements.
+                {% endset %}
+     
+                 {% set digital_outcomes_intro %}
+                        You can use the Digital Marketplace to find a team to work on a digital outcome, such as a booking system or an accessibility audit. 
+                    </p> <p>
+                        You need to write 'requirements' to describe the situation or problem and ask suppliers to propose a solution and provide a team.
+                    </p> <p>
+                        The members of the team can’t work for you outside the scope of your written requirements.
+                {% endset %}
+                
                 {{
                     {
-                    "digital-outcomes": "To find a digital outcome, eg a booking system or an accessibility audit, you need to tell suppliers about the situation or problem. They’ll then propose a solution to meet your needs.",
-                    "digital-specialists": "To find a digital specialist, eg a developer or a user researcher, you need to tell suppliers to provide a specialist for a specific piece of work.",
+                    "digital-specialists": digital_specialists_intro,
+                    "digital-outcomes": digital_outcomes_intro,
                     "user-research-participants": "To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.",
                     }[lot.slug]
                 }}

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -39,29 +39,28 @@
 
     <div class="column-two-thirds large-paragraph">
         <div class="marketplace-paragraph">
-            <p>
                  {% set digital_specialists_intro %}
-                        You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.
-                    </p> <p>
-                        You need to write 'requirements' to describe the work and tell suppliers to provide a specialist. The specialist can’t work for you outside the scope of your written requirements.
+                    <p>You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.</p> 
+                    <p>You need to write ‘requirements’ to describe the work and tell suppliers to provide a specialist. The specialist can’t work for you outside the scope of your written requirements.</p>
                 {% endset %}
      
                  {% set digital_outcomes_intro %}
-                        You can use the Digital Marketplace to find a team to work on a digital outcome, such as a booking system or an accessibility audit. 
-                    </p> <p>
-                        You need to write 'requirements' to describe the situation or problem and ask suppliers to propose a solution and provide a team.
-                    </p> <p>
-                        The members of the team can’t work for you outside the scope of your written requirements.
+                    <p>You can use the Digital Marketplace to find a team to work on a digital outcome, such as a booking system or an accessibility audit.</p>
+                    <p>You need to write ‘requirements’ to describe the situation or problem and ask suppliers to propose a solution and provide a team.</p>
+                    <p>The members of the team can’t work for you outside the scope of your written requirements.</p>
                 {% endset %}
                 
+                {% set user_research_participants_intro %}
+                    <p>To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.</p>   
+                {% endset %}
+            
                 {{
                     {
                     "digital-specialists": digital_specialists_intro,
                     "digital-outcomes": digital_outcomes_intro,
-                    "user-research-participants": "To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.",
+                    "user-research-participants": user_research_participants_intro,
                     }[lot.slug]
                 }}
-            </p>
         </div>
 
         <h2>Before you start</h2>


### PR DESCRIPTION
These changes were made to make it clearer that specialists found through the digital marketplace can only work for buyers within the scope of the written requirements. It was requested by CCS to help users decide which framework to use.