### PR TITLE
Buyers can withdraw briefs

### DIFF
--- a/app/main/forms/award_or_cancel.py
+++ b/app/main/forms/award_or_cancel.py
@@ -3,7 +3,7 @@ from wtforms import RadioField, validators
 
 
 class AwardOrCancelBriefForm(Form):
-    """Form for the buyer to tell us whether they want to award or cancel the requirement
+    """Form for the buyer to tell us whether they want to award or cancel the requirements
     """
     choices = [
         ('yes', 'Yes'),

--- a/app/main/forms/cancel.py
+++ b/app/main/forms/cancel.py
@@ -3,10 +3,10 @@ from wtforms import RadioField, validators
 
 
 class CancelBriefForm(Form):
-    """Form for the buyer to tell us why they are cancelling the requirement
+    """Form for the buyer to tell us why they are cancelling the requirements
     """
     choices = [
-        ('cancel', 'The requirement has been cancelled'),
+        ('cancel', 'Your requirements have been cancelled'),
         ('unsuccessful', 'There were no suitable suppliers'),
     ]
     cancel_reason = RadioField(

--- a/app/main/helpers/buyers_helpers.py
+++ b/app/main/helpers/buyers_helpers.py
@@ -17,12 +17,13 @@ def get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_sta
     return framework, lot
 
 
-def is_brief_correct(brief, framework_slug, lot_slug, current_user_id, allow_withdrawn=False):
+def is_brief_correct(brief, framework_slug, lot_slug, current_user_id, allow_withdrawn=False, allowed_statuses=None):
     return (
         brief['frameworkSlug'] == framework_slug
         and brief['lotSlug'] == lot_slug
         and is_brief_associated_with_user(brief, current_user_id)
         and (True if allow_withdrawn else not brief_is_withdrawn(brief))
+        and (brief['status'] in allowed_statuses if allowed_statuses else True)
     )
 
 

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -411,10 +411,9 @@ def view_brief_responses(framework_slug, lot_slug, brief_id):
     )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
-        abort(404)
-
-    if brief['status'] not in CLOSED_PUBLISHED_BRIEF_STATUSES:
+    if not is_brief_correct(
+        brief, framework_slug, lot_slug, current_user.id, allowed_statuses=CLOSED_PUBLISHED_BRIEF_STATUSES
+    ):
         abort(404)
 
     brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
@@ -462,7 +461,10 @@ def award_or_cancel_brief(framework_slug, lot_slug, brief_id):
     )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
+    if not is_brief_correct(
+        brief, framework_slug, lot_slug, current_user.id,
+        allowed_statuses=["awarded", "cancelled", "unsuccessful", "closed"]
+    ):
         abort(404)
 
     breadcrumbs = get_briefs_breadcrumbs([{
@@ -477,8 +479,6 @@ def award_or_cancel_brief(framework_slug, lot_slug, brief_id):
 
     if brief['status'] in ["awarded", "cancelled", "unsuccessful"]:
         already_awarded = True
-    elif brief['status'] != "closed":
-        abort(404)
     else:
         already_awarded = False
 
@@ -538,10 +538,7 @@ def award_brief(framework_slug, lot_slug, brief_id):
         }
     ])
 
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
-        abort(404)
-
-    if brief['status'] != "closed":
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id, allowed_statuses=['closed']):
         abort(404)
 
     brief_responses = data_api_client.find_brief_responses(
@@ -623,9 +620,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
         must_allow_brief=True,
     )
     brief = data_api_client.get_brief(brief_id)["briefs"]
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
-        abort(404)
-    if brief["status"] != "closed":
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id, allowed_statuses=['closed']):
         abort(404)
 
     if award_flow:
@@ -1041,7 +1036,7 @@ def withdraw_a_brief(framework_slug, lot_slug, brief_id):
     )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or brief['status'] != 'live':
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id, allowed_statuses=['live']):
         abort(404)
 
     data_api_client.withdraw_brief(brief_id, current_user.email_address)
@@ -1066,10 +1061,7 @@ def supplier_questions(framework_slug, lot_slug, brief_id):
     )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
-        abort(404)
-
-    if brief["status"] != "live":
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id, allowed_statuses=['live']):
         abort(404)
 
     brief['clarificationQuestions'] = [
@@ -1098,10 +1090,7 @@ def add_supplier_question(framework_slug, lot_slug, brief_id):
     )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
-        abort(404)
-
-    if brief["status"] != "live":
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id, allowed_statuses=['live']):
         abort(404)
 
     content = content_loader.get_manifest(brief['frameworkSlug'], "clarification_question").filter({})

--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -23,7 +23,7 @@
 
               <form method="POST" action="{{ url_for('.award_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
                   <p class="question-advice">
-                      The information you provide will be shown on the requirement. This makes the buying process more transparent.
+                      The information you provide will be shown on the requirements. This makes the buying process more transparent.
                   </p>
 
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -211,7 +211,7 @@
                 'live': 'You must give your chosen supplier a contract before they start work.',
                 'closed': 'You must give your chosen supplier a contract before they start work.',
                 'awarded': 'Done',
-                'cancelled': 'The contract was not awarded - the requirement was cancelled.',
+                'cancelled': 'The contract was not awarded - the requirements were cancelled.',
                 'unsuccessful': 'The contract was not awarded - no suitable suppliers applied.',
               },
               'body': {
@@ -287,14 +287,14 @@
     </div>
     <div class="column-one-third">
       {% if brief.status == 'closed' %}
-        <a href="{{ url_for('buyers.cancel_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel requirement</a>
+        <a href="{{ url_for('buyers.cancel_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel requirements</a>
       {% elif brief.status == 'live' %}
         {% if not withdraw_requested %}
-          <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, withdraw_requested=True) }}">Withdraw requirement</a>
+          <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, withdraw_requested=True) }}">Withdraw requirements</a>
         {% endif %}
       {% elif brief.status == 'draft' %}
         {% if not delete_requested %}
-          <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, delete_requested=True) }}">Delete draft requirement</a>
+          <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, delete_requested=True) }}">Delete draft requirements</a>
         {% endif %}
       {% endif %}
     </div>

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -29,6 +29,29 @@
           </form>
         </div>
       {% endif %}
+      {% if withdraw_requested %}
+        <div class="column-one-whole">
+          <form action="{{ url_for('buyers.withdraw_a_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            <input type="hidden" name="withdraw_confirmed" value="true" />
+            {% set withdraw_text = "You should only withdraw your requirements if you:" %}
+            {% set withdraw_list_items = [
+                "want to change something that may affect whether suppliers apply, for example, the budget range or role",
+                "can no longer offer the work"
+              ]
+            %}
+            {%
+              with
+              heading = "Are you sure you want to withdraw these requirements?",
+              content = "<p>{}</p><ul><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
+              type = "destructive",
+              action = '<button type="submit" class="button-destructive banner-action">Withdraw requirements</button>'|safe
+            %}
+              {% include "toolkit/notification-banner.html" %}
+            {% endwith %}
+          </form>
+        </div>
+      {% endif %}
 
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
@@ -264,7 +287,9 @@
       {% if brief.status == 'closed' %}
         <a href="{{ url_for('buyers.cancel_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel requirement</a>
       {% elif brief.status == 'live' %}
-        <a href="https://www.gov.uk/guidance/how-to-make-changes-to-your-published-digital-outcomes-and-specialists-requirements#when-to-withdraw-your-requirements">Withdraw requirement</a>
+        {% if not withdraw_requested %}
+          <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, withdraw_requested=True) }}">Withdraw requirement</a>
+        {% endif %}
       {% elif brief.status == 'draft' %}
         {% if not delete_requested %}
           <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, delete_requested=True) }}">Delete draft requirement</a>

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -20,12 +20,14 @@
           <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             <input type="hidden" name="delete_confirmed" value="true" />
-            <div class="banner-destructive-with-action">
-              <p class="banner-message">
-               Are you sure you want to delete these requirements?
-              </p>
-              <button type="submit" class="button-destructive banner-action">Yes, delete</button>
-            </div>
+            {%
+              with
+              message = "Are you sure you want to delete these requirements?",
+              type = "destructive",
+              action = '<button type="submit" class="button-destructive banner-action">Yes, delete</button>'|safe
+            %}
+              {% include "toolkit/notification-banner.html" %}
+            {% endwith %}
           </form>
         </div>
       {% endif %}

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -43,12 +43,12 @@
             {% include "toolkit/forms/selection-buttons.html" %}
           {% endwith %}
 
-          <p>Your requirement will be updated so suppliers can see it. You’ll still need to contact them to let them know what happened and give them feedback.</p>
+          <p>Your requirements will be updated so suppliers can see them. You’ll still need to contact them to let them know what happened and give them feedback.</p>
 
           {% block save_button %}
             {%
               with
-              label="Update requirement",
+              label="Update requirements",
               name="submit",
               type="save"
             %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -32,6 +32,8 @@
                             <p class="banner-message">
                     {% if 'requirements_deleted' in message %}
                             Your requirements &lsquo;{{ message.get('requirements_deleted') }}&rsquo; were deleted
+                    {% elif 'requirements_withdrawn' in message %}
+                            You've withdrawn your requirements for &lsquo;{{ message.get('requirements_withdrawn') }}&rsquo;.
                     {% elif 'updated-brief' in message %}
                             You've updated '{{ message.get('updated-brief') }}'
                     {% else %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#24.3.3",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#24.4.4",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
   }

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.6.0#egg=digitalmarketplace-content-loader==4.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.1.0#egg=digitalmarketplace-apiclient==10.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.1.0#egg=digitalmarketplace-apiclient==11.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.6.0#egg=digitalmarketplace-content-loader==4.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.1.0#egg=digitalmarketplace-apiclient==10.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.1.0#egg=digitalmarketplace-apiclient==11.1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.23.0

--- a/tests/main/helpers/test_buyers_helpers.py
+++ b/tests/main/helpers/test_buyers_helpers.py
@@ -103,6 +103,18 @@ class TestBuyersHelpers(object):
             brief, 'digital-outcomes-and-specialists', 'digital-specialists', 123, allow_withdrawn=allow_withdrawn
         ) is result
 
+    @pytest.mark.parametrize(
+        'allowed_statuses, result', [
+            (['live', 'closed'], True),
+            (['closed'], False)
+        ]
+    )
+    def test_is_brief_correct_allowed_statuses(self, allowed_statuses, result):
+        brief = api_stubs.brief(user_id=123, status='live')['briefs']
+        assert helpers.buyers_helpers.is_brief_correct(
+            brief, 'digital-outcomes-and-specialists', 'digital-specialists', 123, allowed_statuses=allowed_statuses
+        ) is result
+
     def test_is_brief_associated_with_user(self):
         brief = api_stubs.brief(user_id=123)['briefs']
         assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 123) is True

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1775,7 +1775,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Awarded to " not in page_html
             assert self._get_links(document, self.SIDE_LINKS_XPATH) == [
                 (
-                    "Delete draft requirement",
+                    "Delete draft requirements",
                     "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234?delete_requested=True"  # noqa
                 )
             ]
@@ -1820,7 +1820,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Awarded to " not in page_html
             assert self._get_links(document, self.SIDE_LINKS_XPATH) == [
                 (
-                    'Withdraw requirement',
+                    'Withdraw requirements',
                     "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234?withdraw_requested=True"  # noqa
                 )
             ]
@@ -1864,7 +1864,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Awarded to " not in page_html
             assert self._get_links(document, self.SIDE_LINKS_XPATH) == [
                 (
-                    'Cancel requirement',
+                    'Cancel requirements',
                     '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/cancel'
                 )
             ]
@@ -1872,7 +1872,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
     @pytest.mark.parametrize('framework_status', ['live', 'expired'])
     @pytest.mark.parametrize(
         'status,award_description',
-        [('cancelled', 'the requirement was cancelled'), ('unsuccessful', 'no suitable suppliers applied')]
+        [('cancelled', 'the requirements were cancelled'), ('unsuccessful', 'no suitable suppliers applied')]
     )
     def test_show_cancelled_and_unsuccessful_brief_summary_page_for_live_and_expired_framework(
             self, data_api_client, status, award_description, framework_status):
@@ -3638,7 +3638,7 @@ class TestCancelBrief(BaseApplicationTest):
         page_title = document.xpath('//h1')[0].text_content()
         assert "Why do you need to cancel {}?".format(self.brief.get('title')) in page_title
 
-        submit_button = document.xpath('//input[@class="button-save" and @value="Update requirement"]')
+        submit_button = document.xpath('//input[@class="button-save" and @value="Update requirements"]')
         assert len(submit_button) == 1
 
         expected_previous_page_link_text = 'Previous page'
@@ -3680,7 +3680,7 @@ class TestCancelBrief(BaseApplicationTest):
         page_title = document.xpath('//h1')[0].text_content()
         assert "Why didn't you award a contract for {}?".format(self.brief.get('title')) in page_title
 
-        submit_button = document.xpath('//input[@class="button-save" and @value="Update requirement"]')
+        submit_button = document.xpath('//input[@class="button-save" and @value="Update requirements"]')
         assert len(submit_button) == 1
 
         expected_previous_page_link_text = 'Previous page'

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -3878,7 +3878,7 @@ class TestAwardOrCancelBrief(BaseApplicationTest):
     def test_200_for_acceptable_framework_statuses(self, framework_status):
         self.data_api_client.get_framework.return_value['frameworks']['status'] = framework_status
 
-        res = self.client.get(self.url.format(brief_id=123))
+        res = self.client.get(self.url.format(brief_id=self.brief["id"]))
 
         assert res.status_code == 200
 

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -569,112 +569,6 @@ class TestCopyBrief(BaseApplicationTest):
         self.data_api_client.copy_brief.assert_called_once_with('1234', 'buyer@email.com')
 
 
-class TestEveryDamnPage(BaseApplicationTest):
-    def _load_page(self, url, status_code, method='get', data=None, framework_status='live', brief_status='draft'):
-        data = {} if data is None else data
-        baseurl = "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-        with mock.patch('app.main.views.buyers.content_loader', autospec=True) as content_loader, \
-                mock.patch('app.main.views.buyers.data_api_client', autospec=True) as data_api_client:
-            self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status=framework_status,
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                    api_stubs.lot(slug='digital-outcomes', allows_brief=True)
-                ]
-            )
-            brief_stub = api_stubs.brief()
-            brief_stub['briefs'].update({'status': brief_status})
-            if brief_status != 'draft':
-                brief_stub['briefs'].update({'publishedAt': '2017-01-21T12:00:00.000000Z'})
-            data_api_client.get_brief.return_value = brief_stub
-
-            content_fixture = ContentLoader('tests/fixtures/content')
-            content_fixture.load_manifest('dos', 'data', 'edit_brief')
-            content_loader.get_manifest.return_value = content_fixture.get_manifest('dos', 'edit_brief')
-
-            res = getattr(self.client, method)(
-                "{}{}".format(baseurl, url),
-                data=data)
-            assert res.status_code == status_code
-
-    # These should all work as expected
-
-    def test_get_view_brief_overview(self):
-        for framework_status in ['live', 'expired']:
-            self._load_page("/digital-specialists/1234", 200, framework_status=framework_status)
-
-    def test_get_view_section_summary(self):
-        self._load_page("/digital-specialists/1234/section-1", 200)
-
-    def test_get_edit_brief_question(self):
-        self._load_page("/digital-specialists/1234/edit/section-1/required1", 200)
-
-    def test_post_edit_brief_question(self):
-        data = {"required1": True}
-        self._load_page("/digital-specialists/1234/edit/section-1/required1", 302, method='post', data=data)
-
-    def test_get_view_brief_responses(self):
-        for framework_status in ['live', 'expired']:
-            self._load_page("/digital-specialists/1234/responses", 200, brief_status='closed')
-
-    # get and post are the same for publishing
-
-    def test_post_delete_a_brief(self):
-        data = {"delete_confirmed": True}
-        self._load_page("/digital-specialists/1234/delete", 302, method='post', data=data)
-        self.assert_flashes("requirements_deleted")
-
-    def test_post_withdraw_a_brief(self):
-        data = {"withdraw_confirmed": True}
-        self._load_page("/digital-specialists/1234/withdraw", 302, method='post', data=data, brief_status='live')
-        self.assert_flashes("requirements_withdrawn")
-
-    # Wrong lots
-
-    def test_wrong_lot_get_view_brief_overview(self):
-        self._load_page("/digital-outcomes/1234", 404)
-
-    def test_wrong_lot_get_view_section_summary(self):
-        self._load_page("/digital-outcomes/1234/section-1", 404)
-
-    def test_wrong_lot_get_edit_brief_question(self):
-        self._load_page("/digital-outcomes/1234/edit/section-1/required1", 404)
-
-    def test_wrong_lot_post_edit_brief_question(self):
-        data = {"required1": True}
-        self._load_page("/digital-outcomes/1234/edit/section-1/required1", 404, method='post', data=data)
-
-    def test_wrong_lot_get_view_brief_responses(self):
-        self._load_page("/digital-outcomes/1234/responses", 404)
-
-    # get and post are the same for publishing
-    def test_wrong_lot_publish_brief(self):
-        self._load_page("/digital-outcomes/1234/publish", 404)
-
-    @pytest.mark.parametrize('action', ['delete', 'withdraw'])
-    def test_wrong_lot_post_delete_or_withdraw_a_brief(self, action):
-        data = {"{}_confirmed".format(action): True}
-        self._load_page("/digital-outcomes/1234/{}".format(action), 404, method='post', data=data)
-
-    # not allowed for expired framework_slug
-
-    def test_expired_framework_get_edit_brief_question(self):
-        self._load_page("/digital-specialists/1234/edit/section-1/required1", 404, framework_status='expired')
-
-    @pytest.mark.parametrize("lot_slug", ('digital-outcomes', 'digital-specialists'))
-    def test_expired_framework_post_edit_brief_question(self, lot_slug):
-        data = {"required1": True}
-        self._load_page(
-            "/{}/1234/edit/section-1/required1".format(lot_slug),
-            404,
-            method='post',
-            data=data,
-            framework_status='expired'
-        )
-
-
 @mock.patch('app.main.views.buyers.data_api_client', autospec=True)
 class TestEditBriefSubmission(BaseApplicationTest):
 
@@ -876,6 +770,24 @@ class TestEditBriefSubmission(BaseApplicationTest):
         res = self.client.get(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-octopuses"
             "/1234/edit/description-of-work/organisation")
+
+        assert res.status_code == 404
+
+    def test_404_if_post_brief_has_wrong_lot(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+
+        res = self.client.post(
+            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-octopuses"
+            "/1234/edit/description-of-work/organisation",
+            data={"organisation": True}
+        )
 
         assert res.status_code == 404
 
@@ -1141,27 +1053,27 @@ class TestUpdateBriefSubmission(BaseApplicationTest):
         assert res.status_code == 404
         assert not data_api_client.update_brief.called
 
-    def test_404_if_framework_status_is_not_live(self, data_api_client):
-        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
-            self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='open',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True)
-                ]
-            )
-            data_api_client.get_brief.return_value = api_stubs.brief()
+    @pytest.mark.parametrize('framework_status', ['coming', 'open', 'pending', 'standstill', 'expired'])
+    def test_404_if_framework_status_is_not_live(self, data_api_client, framework_status):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status=framework_status,
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+        data_api_client.get_brief.return_value = api_stubs.brief()
 
-            res = self.client.post(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
-                "digital-specialists/1234/edit/description-of-work/organisation",
-                data={
-                    "title": "A new title"
-                })
+        res = self.client.post(
+            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+            "digital-specialists/1234/edit/description-of-work/organisation",
+            data={
+                "title": "A new title"
+            })
 
-            assert res.status_code == 404
-            assert not data_api_client.update_brief.called
+        assert res.status_code == 404
+        assert not data_api_client.update_brief.called
 
     def test_404_if_brief_is_already_live(self, data_api_client):
         self.login_as_buyer()
@@ -1282,6 +1194,27 @@ class TestPublishBrief(BaseApplicationTest):
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
             "digital-specialists/1234/edit/your-organisation",
+            data={
+                "organisation": "GDS"
+            })
+
+        assert res.status_code == 404
+        assert not data_api_client.update_brief.called
+
+    def test_404_if_brief_has_wrong_lot(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+        data_api_client.get_brief.return_value = api_stubs.brief()
+
+        res = self.client.post(
+            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+            "digital-outcomes/1234/edit/your-organisation",
             data={
                 "organisation": "GDS"
             })
@@ -1589,6 +1522,7 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
             assert res.status_code == 302
             assert data_api_client.delete_brief.called
             assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
+            self.assert_flashes("requirements_deleted")
 
     def test_404_if_framework_is_not_live_or_expired(self, data_api_client):
         for framework_status in ['coming', 'open', 'pending', 'standstill']:
@@ -1644,12 +1578,29 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
 
         assert res.status_code == 404
 
+    def test_404_if_brief_has_wrong_lot(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+        data_api_client.get_brief.return_value = api_stubs.brief()
+
+        res = self.client.post(
+            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-outcomes/1234/delete",
+            data={"delete_confirmed": True})
+
+        assert res.status_code == 404
+
 
 @mock.patch('app.main.views.buyers.data_api_client', autospec=True)
 class TestWithdrawBriefSubmission(BaseApplicationTest):
 
     @pytest.mark.parametrize('framework_status', ['live', 'expired'])
-    def test_delete_brief_submission(self, data_api_client, framework_status):
+    def test_withdraw_brief_submission(self, data_api_client, framework_status):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug='digital-outcomes-and-specialists',
@@ -1666,6 +1617,7 @@ class TestWithdrawBriefSubmission(BaseApplicationTest):
         assert res.status_code == 302
         assert data_api_client.delete_brief.call_args_list == []
         assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
+        self.assert_flashes("requirements_withdrawn")
 
     @pytest.mark.parametrize('framework_status', ['coming', 'open', 'pending', 'standstill'])
     def test_404_if_framework_is_not_live_or_expired(self, data_api_client, framework_status):
@@ -1709,12 +1661,29 @@ class TestWithdrawBriefSubmission(BaseApplicationTest):
             status='live',
             lots=[api_stubs.lot(slug='digital-specialists', allows_brief=True)]
         )
-        data_api_client.get_brief.return_value = api_stubs.brief(user_id=234)
+        data_api_client.get_brief.return_value = api_stubs.brief(user_id=234, status='live')
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/withdraw",
             data={"withdraw_confirmed": True}
         )
+
+        assert res.status_code == 404
+
+    def test_404_if_brief_has_wrong_lot(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+
+        res = self.client.post(
+            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-outcomes/1234/withdraw",
+            data={"delete_confirmed": True})
 
         assert res.status_code == 404
 
@@ -1733,12 +1702,13 @@ class TestBriefSummaryPage(BaseApplicationTest):
             (e.text_content(), e.get('href')) for e in document.xpath(xpath)
         ]
 
-    def test_show_draft_brief_summary_page(self, data_api_client):
+    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
+    def test_show_draft_brief_summary_page(self, data_api_client, framework_status):
         with self.app.app_context():
             self.login_as_buyer()
             data_api_client.get_framework.return_value = api_stubs.framework(
                 slug='digital-outcomes-and-specialists',
-                status='live',
+                status=framework_status,
                 lots=[
                     api_stubs.lot(slug='digital-specialists', allows_brief=True),
                 ]
@@ -2102,6 +2072,24 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
             assert res.status_code == 404
 
+    def test_404_if_brief_has_wrong_lot(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            data_api_client.get_brief.return_value = api_stubs.brief()
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-outcomes/1234"
+            )
+
+            assert res.status_code == 404
+
     @mock.patch("app.main.views.buyers.content_loader", autospec=True)
     def test_links_to_sections_go_to_the_correct_pages_whether_they_be_sections_or_questions(self, content_loader, data_api_client):  # noqa
         with self.app.app_context():
@@ -2141,6 +2129,51 @@ class TestBriefSummaryPage(BaseApplicationTest):
             # section with single question and a description
             assert section_4_link[0].get('href').strip() == \
                 '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-4'
+
+
+@mock.patch('app.main.views.buyers.data_api_client', autospec=True)
+class TestViewBriefSectionSummaryPage(BaseApplicationTest):
+
+    @mock.patch('app.main.views.buyers.content_loader', autospec=True)
+    def test_get_view_section_summary(self, content_loader, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            data_api_client.get_brief.return_value = api_stubs.brief()
+
+            content_fixture = ContentLoader('tests/fixtures/content')
+            content_fixture.load_manifest('dos', 'data', 'edit_brief')
+            content_loader.get_manifest.return_value = content_fixture.get_manifest('dos', 'edit_brief')
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-1"
+            )
+
+            assert res.status_code == 200
+
+    def test_wrong_lot_get_view_section_summary(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            data_api_client.get_brief.return_value = api_stubs.brief()
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-outcomes/1234/section-1"
+            )
+
+            assert res.status_code == 404
 
 
 @mock.patch("app.main.views.buyers.data_api_client", autospec=True)
@@ -2444,6 +2477,22 @@ class AbstractViewBriefResponsesPage(BaseApplicationTest):
             status='live',
             lots=[
                 api_stubs.lot(slug='digital-outcomes', allows_brief=False),
+            ]
+        )
+
+        self.login_as_buyer()
+        res = self.client.get(
+            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-outcomes/1234/responses"
+        )
+
+        assert res.status_code == 404
+
+    def test_404_if_brief_has_wrong_lot(self):
+        self.data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True),
             ]
         )
 


### PR DESCRIPTION
Trello ticket: https://trello.com/c/7kq7pSTr/83-allow-buyers-withdraw-open-opportunities

New link:
![withdraw1](https://user-images.githubusercontent.com/3492540/31901750-4cd47396-b81a-11e7-9e27-8e765d37991e.png)
Confirm banner:
![withdraw2](https://user-images.githubusercontent.com/3492540/31901759-533dd04c-b81a-11e7-8dea-27efe7cdd3f7.png)
Success banner:
![withdraw3](https://user-images.githubusercontent.com/3492540/31901769-5a4afebe-b81a-11e7-9426-6ae3a05cc1ec.png)


- Buyers can now withdraw live requirements from the Brief summary page, in the same way that they would delete a draft requirement. The view and tests are based almost entirely on what's currently there for the delete flow - there may well be some gaps.
- Pulls in changes from the API client (merged) and the Frontend Toolkit (now merged)
- Fixes occurrences of `requirement` that were not pluralised (now confirmed with Constance).

Should now be ready for merging, although be aware that some functional tests will break with the copy changes. 