### PR TITLE
Use new notification banner template

### DIFF
--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -45,7 +45,7 @@
             {%
               with
               heading = "Are you sure you want to withdraw these requirements?",
-              content = "<p>{}</p><ul><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
+              banner_content = "<p>{}</p><ul><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
               type = "destructive",
               action = '<button type="submit" class="button-destructive banner-action">Withdraw requirements</button>'|safe
             %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#24.4.4",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#25.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
   }


### PR DESCRIPTION
This PR pulls in the frontend toolkit changes to notification banner, which now uses `banner_content` instead of `content` for the Withdraw Opportunity banner text:

![withdraw-opportunity-banner](https://user-images.githubusercontent.com/3492540/33079761-51bd6686-cece-11e7-99b0-ce8153e9aa6f.png)

(This was causing a problem in the Buyer FE - see https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/388 for details of the fix).
