### PR TITLE
Pull in v4.8.0 of content loader

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,5 +6,5 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.6.0#egg=digitalmarketplace-content-loader==4.6.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.8.0#egg=digitalmarketplace-content-loader==4.8.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.1.0#egg=digitalmarketplace-apiclient==11.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.6.0#egg=digitalmarketplace-content-loader==4.6.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.8.0#egg=digitalmarketplace-content-loader==4.8.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.1.0#egg=digitalmarketplace-apiclient==11.1.0
 
 ## The following requirements were added by pip freeze:
@@ -26,7 +26,7 @@ future==0.16.0
 idna==2.6
 inflection==0.2.1
 itsdangerous==0.24
-Jinja2==2.9.6
+Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.11
 mandrill==1.0.57


### PR DESCRIPTION
Trello: https://trello.com/c/77L1kwqj/28-list-of-errors-in-header-in-incorrect-order-for-brief-weighting-question

This pulls in the fix for the multi-question error message bug (errors should appear in order of the questions, instead of alphabetical order).