### PR TITLE
Test case for ODF data containing characters disallowed in XML.

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,10 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
+# Dependencies where the library is not on pypi (or, in the case of odfpy, where the version on pypi is buggy):
+
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
+
+git+https://github.com/alphagov/digitalmarketplace-utils.git@31.0.0#egg=digitalmarketplace-utils==31.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.8.0#egg=digitalmarketplace-content-loader==4.8.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,11 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
+# Dependencies where the library is not on pypi (or, in the case of odfpy, where the version on pypi is buggy):
+
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
+
+git+https://github.com/alphagov/digitalmarketplace-utils.git@31.0.0#egg=digitalmarketplace-utils==31.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.8.0#egg=digitalmarketplace-content-loader==4.8.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 
@@ -36,7 +40,6 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
-odfpy==1.3.3
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1


### PR DESCRIPTION
Bug fix will be in external ODF library, to follow. (Tests won't pass here until we update our dependencies.)

https://trello.com/c/EgBoNeW9/145-certain-control-characters-in-suppliers-evidence-corrupts-the-ods-that-buyers-download