### PR TITLE
Change from flake8-putty to flake8-per-file-ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,13 +3,12 @@
 # D203: 1 blank line required before class docstring
 # F401: 'identifier' imported but unused
 # E402: module level import not at top of file
-# C901: too complex
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 13
 max-line-length = 120
-putty-ignore =
-    app/__init__.py, app/main/__init__.py, app/status/__init__.py : +F401
-    app/__init__.py, app/main/__init__.py, app/status/__init__.py, app/create_buyer/__init__.py, app/external/__init__.py : +E402
-    app/__init__.py, app/main/views/*.py : +C901
+per-file-ignores =
+    app/main/__init__.py : E402, F401
+    app/status/__init__.py : E402, F401
+    app/external/__init__.py : E402

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ watchdog==0.8.3
 freezegun==0.3.4
 
 coverage==3.7.1
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 pytest-cov==2.5.1
 python-coveralls==2.5.0

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -2964,22 +2964,20 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
 
         sheet = doc.sheet("Supplier evidence")
 
-        k = 0
+        row = 0
+        for question in questions:
+            for name_idx, name in enumerate(self.brief[question['id']]):
+                row += 1
 
-        for i, question in enumerate(questions):
-
-            for l, name in enumerate(self.brief[question['id']]):
-                k += 1
-
-                if l == 0:
-                    assert sheet.read_cell(0, k) == question['name']
+                if name_idx == 0:
+                    assert sheet.read_cell(0, row) == question['name']
                 else:
-                    assert sheet.read_cell(0, k) == ''
+                    assert sheet.read_cell(0, row) == ''
 
-                assert sheet.read_cell(1, k) == name
+                assert sheet.read_cell(1, row) == name
 
-                for j, response in enumerate(self.responses):
-                    assert sheet.read_cell(j + 2, k) == str(response[question['id']][l]).lower()
+                for col, response in enumerate(self.responses):
+                    assert sheet.read_cell(col + 2, row) == str(response[question['id']][name_idx]).lower()
 
     def test_populate_styled_ods_with_data_with_dynamic_list(self):
         questions = [
@@ -2996,22 +2994,20 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
 
         sheet = doc.sheet("Supplier evidence")
 
-        k = 0
+        row = 0
+        for question in questions:
+            for name_idx, name in enumerate(self.brief[question['id']]):
+                row += 1
 
-        for i, question in enumerate(questions):
-
-            for l, name in enumerate(self.brief[question['id']]):
-                k += 1
-
-                if l == 0:
-                    assert sheet.read_cell(0, k) == question['name']
+                if name_idx == 0:
+                    assert sheet.read_cell(0, row) == question['name']
                 else:
-                    assert sheet.read_cell(0, k) == ''
+                    assert sheet.read_cell(0, row) == ''
 
-                assert sheet.read_cell(1, k) == name
+                assert sheet.read_cell(1, row) == name
 
-                for j, response in enumerate(self.responses):
-                    assert sheet.read_cell(j + 2, k) == response[question['id']][l].get('evidence', '')
+                for col, response in enumerate(self.responses):
+                    assert sheet.read_cell(col + 2, row) == response[question['id']][name_idx].get('evidence', '')
 
     def test_populate_styled_ods_with_data_missing_with_dynamic_list(self):
         questions = [


### PR DESCRIPTION
This allows us to support newer Python3 syntax such as f-strings and
type annotations.

Flake8 report:
```
samuelwilliams:~/git/digitalmarketplace-briefs-frontend [shw-flake8-per-file-ignores]$ make test-flake8
[ -z $VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
/Users/samuelwilliams/git/digitalmarketplace-briefs-frontend/venv/bin/flake8 .
./app/__init__.py:0:1: X100 Superfluous per-file-ignores for F401
./app/__init__.py:0:1: X100 Superfluous per-file-ignores for E402
./app/__init__.py:0:1: X100 Superfluous per-file-ignores for C901
./app/create_buyer/__init__.py:0:1: X100 Superfluous per-file-ignores for E402
./app/main/views/__init__.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/buyers.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/digital_outcomes_and_specialists.py:0:1: X100 Superfluous per-file-ignores for C901
./tests/main/views/test_buyers.py:2962:20: E741 ambiguous variable name 'l'
./tests/main/views/test_buyers.py:2994:20: E741 ambiguous variable name 'l'
make: *** [test-flake8] Error 1
```