### PR TITLE
Upgrade API client to v.13.1.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.8.0#egg=digitalmarketplace-content-loader==4.8.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.1.0#egg=digitalmarketplace-apiclient==11.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,5 +11,5 @@ freezegun==0.3.4
 coverage==3.7.1
 flake8==2.6.2
 flake8-putty==0.4.0
-pytest-cov==2.2.0
+pytest-cov==2.5.1
 python-coveralls==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,16 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.8.0#egg=digitalmarketplace-content-loader==4.8.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.1.0#egg=digitalmarketplace-apiclient==11.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.23.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
+certifi==2017.11.5
 cffi==1.11.2
+chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
@@ -41,10 +43,11 @@ python-dateutil==2.6.1
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
-requests==2.7.0
-s3transfer==0.1.11
+requests==2.18.4
+s3transfer==0.1.12
 six==1.9.0
 unicodecsv==0.14.1
+urllib3==1.22
 Werkzeug==0.12.2
 workdays==1.4
 WTForms==2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = venv* app/content bower_components node_modules


### PR DESCRIPTION
Addresses a vulnerability in the Python requests library.

None of the breaking changes (search API, update_user) affect the Briefs FE app.

Also fixes pytest deprecation warnings.