### PR TITLE
Update frameworks and safely load manifests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ from flask_wtf.csrf import CsrfProtect
 
 import dmapiclient
 from dmutils import init_app, flask_featureflags
+from dmcontent.utils import try_load_manifest
 from dmcontent.content_loader import ContentLoader
 from dmutils.user import User
 
@@ -35,11 +36,12 @@ def create_app(config_name):
         if not framework_data['slug'] in application.config.get('DM_FRAMEWORK_CONTENT_MAP', {}):
             if framework_data['framework'] == 'g-cloud':
                 if framework_data['status'] != 'expired':
-                    content_loader.load_manifest(framework_data['slug'], 'services', 'search_filters')
-                # we need to be able to display old services, even on expired frameworks
-                content_loader.load_manifest(framework_data['slug'], 'services', 'display_service')
+                    try_load_manifest(content_loader, application, framework_data, 'services',
+                                      'services_search_filters')
+
+                try_load_manifest(content_loader, application, framework_data, 'services', 'display_service')
             elif framework_data['framework'] == 'digital-outcomes-and-specialists':
-                content_loader.load_manifest(framework_data['slug'], 'briefs', 'display_brief')
+                try_load_manifest(content_loader, application, framework_data, 'briefs', 'display_brief')
 
     from .create_buyer.views.create_buyer import create_buyer as create_buyer_blueprint
     from .main import dos as dos_blueprint

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#26.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.2.0"
   }
 }

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,5 +10,5 @@ Flask-WTF==0.12
 git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@31.0.0#egg=digitalmarketplace-utils==31.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.8.0#egg=digitalmarketplace-content-loader==4.8.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Flask-WTF==0.12
 git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@31.0.0#egg=digitalmarketplace-utils==31.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.8.0#egg=digitalmarketplace-content-loader==4.8.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 
 ## The following requirements were added by pip freeze:


### PR DESCRIPTION
## Summary
Update frameworks version to 10.2.0 to bring in DOS3. Also catch errors (and log) when loading a manifest fails, so that the app can still come up.

## Ticket
https://trello.com/c/tnBdllTV/156-briefs-frontend-has-crashed-on-preview-wont-come-back-up