### PR TITLE
Update header to make it easier to find support, guidance and where to log in

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -10,6 +10,10 @@
 
 {% block header_class %}with-proposition{% endblock %}
 
+{% block inside_header %}
+  {% include "toolkit/inside-header.html" %}
+{% endblock %}
+
 {% block proposition_header %}
   {% include "toolkit/proposition-header.html" %}
 {% endblock %}
@@ -17,9 +21,6 @@
 {% block content %}
     {% block top_header %}
     {% endblock %}
-{% block phase_banner %}
-  {% include "toolkit/phase-banner.html" %}
-{% endblock %}
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#27.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
   },

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.1#egg=digitalmarketplace-utils==33.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.1#egg=digitalmarketplace-utils==33.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d68e13e0855d18a6e08edcc6ab6738d9ce267ae2"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#27.0.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.0.0":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#bec67d8d44fa0f279be32786e7fb75a6e1981629"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#62e640ed4ee5d793fd18b9b642fce0d965cf59ba"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
This is part of a larger piece of work to change the homepage styling so it is easier to find things on the page and consistent with other services in the service toolkit.

Examples of other pages that use this pattern can be found under the components heading on the service toolkit. https://www.gov.uk/service-toolkit

The code for these pages can be found here: https://github.com/alphagov/product-page-example

As part of this work we will make support easier to find and remove the beta phase banner

The guidance link would go to: https://www.gov.uk/government/collections/digital-marketplace-buyers-and-suppliers-information

The GOV.UK Digital Marketplace logo would go to the digital marketplace home page.

Ticket ID: https://trello.com/c/mityCieG/106-update-header-to-make-it-easier-to-find-support-guidance-and-where-to-log-in

<img width="1139" alt="screen shot 2018-01-12 at 11 15 26" src="https://user-images.githubusercontent.com/4599889/34872723-f170be4c-f789-11e7-9332-23b0824b1514.png">
