### PR TITLE
Revert back to eea/odfpy

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,9 +51,12 @@ def create_app(config_name):
 
     application.register_blueprint(create_buyer_blueprint, url_prefix='/buyers')
     application.register_blueprint(dos_blueprint, url_prefix='/buyers')
-    application.register_blueprint(external_blueprint)
     application.register_blueprint(main_blueprint, url_prefix='/buyers')
     application.register_blueprint(status_blueprint, url_prefix='/buyers')
+
+    # Must be registered last so that any routes declared in the app are registered first (i.e. take precedence over
+    # the external NotImplemented routes in the dm-utils external blueprint).
+    application.register_blueprint(external_blueprint)
 
     login_manager.login_view = 'external.render_login'
     login_manager.login_message_category = "must_login"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,10 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-# Dependencies where the library is not on pypi (or, in the case of odfpy, where the version on pypi is buggy):
-
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
-
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.1.0#egg=digitalmarketplace-utils==31.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,21 +6,17 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-# Dependencies where the library is not on pypi (or, in the case of odfpy, where the version on pypi is buggy):
-
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
-
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.1.0#egg=digitalmarketplace-utils==31.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.23.0
+asn1crypto==0.24.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
-certifi==2017.11.5
-cffi==1.11.2
+certifi==2018.1.18
+cffi==1.11.4
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
@@ -40,6 +36,7 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
+odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1
@@ -51,6 +48,6 @@ s3transfer==0.1.12
 six==1.9.0
 unicodecsv==0.14.1
 urllib3==1.22
-Werkzeug==0.12.2
+Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.1


### PR DESCRIPTION
Update utils to use eea/odfpy rather than our interim alphagov/odfpy
fork, which we created to allow us to patch a bug. Now that the bug has
been accepted into the main library as of release 1.3.6
(https://github.com/eea/odfpy/pull/72) we no longer need to support own
our fork.

Also adds a comment when registering the external blueprint from 
dm-utils to ensure it is registered last.