### PR TITLE
Update Award flow with content changes

### DIFF
--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -23,7 +23,10 @@
 
               <form method="POST" action="{{ url_for('.award_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
                   <p class="question-advice">
-                      The information you provide will be shown on the requirements. This makes the buying process more transparent.
+                      This information will be added to your requirements. Suppliers will receive a link to view the update.
+                  </p>
+                  <p class="question-advice">
+                      You’ll still need to contact suppliers to give them feedback.
                   </p>
 
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -41,7 +41,7 @@
           {% block save_button %}
             {%
               with
-              label="Submit",
+              label="Update requirements",
               name="submit",
               type="save"
             %}

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -37,7 +37,6 @@
           {% include 'toolkit/page-heading.html' %}
         {% endwith %}
 
-          <p class="question-advice">The information you provide will be shown on the opportunity. This makes the buying process more transparent.</p>
           <form method="POST" action="{{ url_for('.award_or_cancel_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             {%

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -31,6 +31,12 @@
 
         <form method="POST" action="{{ url_for(request.endpoint, framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <p class="question-advice">
+              This information will be added to your requirements. Suppliers will receive a link to view the update.
+          </p>
+          <p class="question-advice">
+              You’ll still need to contact suppliers to give them feedback.
+          </p>
           {%
             with
             name = "cancel_reason",
@@ -42,8 +48,6 @@
           %}
             {% include "toolkit/forms/selection-buttons.html" %}
           {% endwith %}
-
-          <p>Your requirements will be updated so suppliers can see them. You’ll still need to contact them to let them know what happened and give them feedback.</p>
 
           {% block save_button %}
             {%

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -3573,7 +3573,7 @@ class TestAwardBriefDetails(BaseApplicationTest):
         page_title = self._strip_whitespace(document.xpath('//h1')[0].text_content())
         assert page_title == "TellusaboutyourcontractwithBananaCorp"
 
-        submit_button = document.xpath('//input[@class="button-save" and @value="Submit"]')
+        submit_button = document.xpath('//input[@class="button-save" and @value="Update requirements"]')
         assert len(submit_button) == 1
 
         secondary_link_text = document.xpath('//div[@class="secondary-action-link"]//a[1]')[0]


### PR DESCRIPTION
Trello: https://trello.com/c/AFg4WfRP/334-let-buyers-know-that-suppliers-will-be-alerted-when-they-update-the-award-status

Content changes applied - this should be merged after the update to the functional tests (https://github.com/alphagov/digitalmarketplace-functional-tests/pull/470).

1) Have you awarded a contract for Foo (Yes/No)
![award-flow-content-yesno](https://user-images.githubusercontent.com/3492540/36376076-ba0bbaf8-1569-11e8-88c4-3acbe116c0f7.png)

2) Who won the Foo contract (Yes flow, page 1)
![award-flow-content-who](https://user-images.githubusercontent.com/3492540/36376098-d05ddb42-1569-11e8-8e48-a112f42ed5b1.png)

3) Tell us about the Foo contract (Yes flow, page 2)
![award-flow-content-details](https://user-images.githubusercontent.com/3492540/36376115-db862ae2-1569-11e8-9e16-929e02741cb1.png)

4) Why didn't you award a contract for Foo (No flow)
![award-flow-content-no](https://user-images.githubusercontent.com/3492540/36376132-ea58fb76-1569-11e8-8869-14beb900ba0b.png)
 