### PR TITLE
Move flash messages out of template

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,6 +1,8 @@
-from flask import Blueprint, current_app, flash
-from flask_login import current_user, login_required
+from functools import partial
+from flask import Blueprint
 from dmcontent.content_loader import ContentLoader
+from dmutils.access_control import require_login
+
 
 main = Blueprint('buyers', __name__)
 dos = Blueprint('dos', __name__)
@@ -18,12 +20,7 @@ content_loader.load_manifest('digital-outcomes-and-specialists-2', 'clarificatio
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'award_brief')
 
 
-@main.before_request
-@login_required
-def require_login():
-    if current_user.is_authenticated() and current_user.role != 'buyer':
-        flash('buyer-role-required', 'error')
-        return current_app.login_manager.unauthorized()
+main.before_request(partial(require_login, role='buyer'))
 
 
 @main.after_request

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -31,9 +31,9 @@ from collections import Counter
 CLOSED_BRIEF_STATUSES = ['closed', 'withdrawn', 'awarded', 'cancelled', 'unsuccessful']
 CLOSED_PUBLISHED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
 
-BRIEF_UPDATED_MESSAGE = "You've updated '{brief[title]}'"
+BRIEF_UPDATED_MESSAGE = "You’ve updated ‘{brief[title]}’"
 BRIEF_DELETED_MESSAGE = "Your requirements ‘{brief[title]}’ were deleted"
-BRIEF_WITHDRAWN_MESSAGE = "You've withdrawn your requirements for ‘{brief[title]}’"
+BRIEF_WITHDRAWN_MESSAGE = "You’ve withdrawn your requirements for ‘{brief[title]}’"
 
 
 @main.route('')

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -31,6 +31,10 @@ from collections import Counter
 CLOSED_BRIEF_STATUSES = ['closed', 'withdrawn', 'awarded', 'cancelled', 'unsuccessful']
 CLOSED_PUBLISHED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
 
+BRIEF_UPDATED_MESSAGE = "You've updated '{brief[title]}'"
+BRIEF_DELETED_MESSAGE = "Your requirements ‘{brief[title]}’ were deleted"
+BRIEF_WITHDRAWN_MESSAGE = "You've withdrawn your requirements for ‘{brief[title]}’"
+
 
 @main.route('')
 def buyer_dashboard():
@@ -492,7 +496,7 @@ def award_or_cancel_brief(framework_slug, lot_slug, brief_id):
             else:
                 answer = form.data.get('award_or_cancel_decision')
                 if answer == 'back':
-                    flash({"updated-brief": brief.get("title")})
+                    flash(BRIEF_UPDATED_MESSAGE.format(brief=brief))
                     return redirect(url_for('.buyer_dos_requirements'))
                 elif answer == 'yes':
                     return redirect(
@@ -662,7 +666,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
                     )
                 else:
                     abort(400, "Unrecognized status '{}'".format(new_status))
-                flash({"updated-brief": brief.get("title")})
+                flash(BRIEF_UPDATED_MESSAGE.format(brief=brief))
                 return redirect(
                     url_for('.view_brief_overview', framework_slug=framework_slug, lot_slug=lot_slug, brief_id=brief_id)
                 )
@@ -747,7 +751,7 @@ def award_brief_details(framework_slug, lot_slug, brief_id, brief_response_id):
                 breadcrumbs=breadcrumbs,
             ), 400
 
-        flash({"updated-brief": brief.get("title")})
+        flash(BRIEF_UPDATED_MESSAGE.format(brief=brief))
 
         if flask_featureflags.is_active('DIRECT_AWARD_PROJECTS'):
             return redirect(url_for(".buyer_dos_requirements"))
@@ -1017,7 +1021,7 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
         abort(404)
 
     data_api_client.delete_brief(brief_id, current_user.email_address)
-    flash({"requirements_deleted": brief.get("title")})
+    flash(BRIEF_DELETED_MESSAGE.format(brief=brief))
 
     if flask_featureflags.is_active('DIRECT_AWARD_PROJECTS'):
         return redirect(url_for(".buyer_dos_requirements"))
@@ -1040,7 +1044,7 @@ def withdraw_a_brief(framework_slug, lot_slug, brief_id):
         abort(404)
 
     data_api_client.withdraw_brief(brief_id, current_user.email_address)
-    flash({"requirements_withdrawn": brief.get("title")})
+    flash(BRIEF_WITHDRAWN_MESSAGE.format(brief=brief))
 
     if flask_featureflags.is_active('DIRECT_AWARD_PROJECTS'):
         return redirect(url_for(".buyer_dos_requirements"))

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -60,7 +60,7 @@
           {% for category, message in messages %}
             {%
             with
-            message = "You've updated '{}'".format(message.get('updated-brief')) if 'updated-brief' in message else message,
+            message = message,
             type = "destructive-without-action" if category == "error" else "success"
             %}
               {% include "toolkit/notification-banner.html" %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -30,15 +30,7 @@
                             <div class="banner-success-without-action">
                         {% endif %}
                                 <p class="banner-message">
-                        {% if 'requirements_deleted' in message %}
-                                Your requirements &lsquo;{{ message.get('requirements_deleted') }}&rsquo; were deleted
-                        {% elif 'requirements_withdrawn' in message %}
-                                You've withdrawn your requirements for &lsquo;{{ message.get('requirements_withdrawn') }}&rsquo;.
-                        {% elif 'updated-brief' in message %}
-                                You've updated '{{ message.get('updated-brief') }}'
-                        {% else %}
-                            {{ message }}
-                        {% endif %}
+                                    {{ message }}
                                 </p>
                             </div>
                     {% endfor %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.1#egg=digitalmarketplace-utils==33.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.1.0#egg=digitalmarketplace-utils==33.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,5 @@ flake8==3.5.0
 flake8-per-file-ignores==0.4.0
 pytest-cov==2.5.1
 python-coveralls==2.5.0
+
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.0.0#egg=digitalmarketplace-test-utils==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.1#egg=digitalmarketplace-utils==33.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.1.0#egg=digitalmarketplace-utils==33.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 
@@ -44,7 +44,7 @@ python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4
-s3transfer==0.1.12
+s3transfer==0.1.13
 six==1.9.0
 unicodecsv==0.14.1
 urllib3==1.22

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,43 +13,7 @@ from mock import patch
 from werkzeug.http import parse_cookie
 
 from dmutils.formats import DATETIME_FORMAT
-
-from flask import Blueprint
-from dmutils.user import User
-from flask_login import login_user
-
-
-login_for_tests = Blueprint('login_for_tests', __name__)
-
-
-@login_for_tests.route('/auto-buyer-login')
-def auto_buyer_login():
-    user_json = {"users": {
-        'id': 123,
-        'name': u'Ā Buyer',
-        'emailAddress': 'buyer@email.com',
-        'role': 'buyer'
-    }
-    }
-    user = User.from_json(user_json)
-    login_user(user)
-    return "OK"
-
-
-@login_for_tests.route('/auto-supplier-login')
-def auto_supplier_login():
-    user_json = {"users": {
-        'id': 123,
-        'name': u'Ā Buyer',
-        'emailAddress': 'supplier@email.com',
-        'supplierId': 1234,
-        'supplierName': 'Supplier Name',
-        'role': 'supplier',
-    }
-    }
-    user = User.from_json(user_json)
-    login_user(user)
-    return "OK"
+from dmtestutils.login import login_for_tests
 
 
 class BaseApplicationTest(object):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -249,7 +249,7 @@ class BaseApplicationTest(object):
                 category, message = session['_flashes'][0]
             except KeyError:
                 raise AssertionError('nothing flashed')
-            assert expected_message in message
+            assert expected_message in message, "Didn't find '{}' in '{}'".format(expected_message, message)
             assert expected_category == category
 
     def assert_breadcrumbs(self, response, extra_breadcrumbs=None):

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1608,7 +1608,7 @@ class TestWithdrawBriefSubmission(BaseApplicationTest):
         assert res.status_code == 302
         assert data_api_client.delete_brief.call_args_list == []
         assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-        self.assert_flashes("You've withdrawn your requirements for ‘I need a thing to do a thing’")
+        self.assert_flashes("You’ve withdrawn your requirements for ‘I need a thing to do a thing’")
 
     @pytest.mark.parametrize('framework_status', ['coming', 'open', 'pending', 'standstill'])
     def test_404_if_framework_is_not_live_or_expired(self, data_api_client, framework_status):
@@ -3598,7 +3598,7 @@ class TestAwardBriefDetails(BaseApplicationTest):
             )
             assert res.status_code == 302
             assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-            self.assert_flashes("You've updated 'I need a thing to do a thing'", "message")
+            self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", "message")
 
     @mock.patch('app.main.views.buyers.is_brief_correct')
     def test_award_brief_details_raises_400_if_brief_not_correct(self, is_brief_correct):
@@ -3893,7 +3893,7 @@ class TestCancelBrief(BaseApplicationTest):
 
         assert res.status_code == 302
         assert expected_url in redirect_text
-        self.assert_flashes("You've updated 'I need a thing to do a thing'", "message")
+        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", "message")
 
 
 class TestBuyerAccountOverview(BaseApplicationTest):
@@ -4033,7 +4033,7 @@ class TestAwardOrCancelBrief(BaseApplicationTest):
         self.login_as_buyer()
         self.client.post(self.url.format(brief_id=self.brief['id']), data={'award_or_cancel_decision': 'back'})
 
-        self.assert_flashes("You've updated 'I need a thing to do a thing'", "message")
+        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", "message")
 
     def test_random_post_data_triggers_invalid_choice(self):
         self.login_as_buyer()

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -238,7 +238,7 @@ class TestBuyerRoleRequired(BaseApplicationTest):
             assert res.location == 'http://localhost/user/login?next={}'.format(
                 self.briefs_dashboard_url.replace('/', '%2F')
             )
-            self.assert_flashes('buyer-role-required', expected_category='error')
+            self.assert_flashes('You must log in with a buyer account to see this page.', expected_category='error')
 
     @mock.patch('app.main.views.buyers.data_api_client')
     def test_buyer_pages_ok_if_logged_in_as_buyer(self, data_api_client):

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -20,6 +20,7 @@ import inflection
 
 from werkzeug.exceptions import NotFound
 
+
 po = functools.partial(mock.patch.object, autospec=True)
 
 
@@ -218,19 +219,6 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert unsuccessful_row_cells[1] == "Tuesday 16 February 2016"
         assert "View responses" not in unsuccessful_row_cells[2]
         assert "Let suppliers know the outcome" not in unsuccessful_row_cells[2]
-
-    def test_flash_message_shown_if_brief_has_just_been_updated(self, data_api_client, find_briefs_mock):
-        data_api_client.find_briefs.return_value = find_briefs_mock
-
-        with self.client.session_transaction() as session:
-            session['_flashes'] = [
-                ('message', {'updated-brief': "My Amazing Brief"})
-            ]
-
-        res = self.client.get(self.briefs_dashboard_url)
-
-        flash_div = html.fromstring(res.get_data(as_text=True)).xpath('//div[@class="banner-success-without-action"]')
-        assert flash_div[0].text_content().strip() == "You've updated 'My Amazing Brief'"
 
 
 class TestBuyerRoleRequired(BaseApplicationTest):
@@ -1525,7 +1513,7 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
             assert res.status_code == 302
             assert data_api_client.delete_brief.called
             assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-            self.assert_flashes("requirements_deleted")
+            self.assert_flashes("Your requirements ‘I need a thing to do a thing’ were deleted")
 
     def test_404_if_framework_is_not_live_or_expired(self, data_api_client):
         for framework_status in ['coming', 'open', 'pending', 'standstill']:
@@ -1620,7 +1608,7 @@ class TestWithdrawBriefSubmission(BaseApplicationTest):
         assert res.status_code == 302
         assert data_api_client.delete_brief.call_args_list == []
         assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-        self.assert_flashes("requirements_withdrawn")
+        self.assert_flashes("You've withdrawn your requirements for ‘I need a thing to do a thing’")
 
     @pytest.mark.parametrize('framework_status', ['coming', 'open', 'pending', 'standstill'])
     def test_404_if_framework_is_not_live_or_expired(self, data_api_client, framework_status):
@@ -3610,7 +3598,7 @@ class TestAwardBriefDetails(BaseApplicationTest):
             )
             assert res.status_code == 302
             assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-            self.assert_flashes("updated-brief")
+            self.assert_flashes("You've updated 'I need a thing to do a thing'", "message")
 
     @mock.patch('app.main.views.buyers.is_brief_correct')
     def test_award_brief_details_raises_400_if_brief_not_correct(self, is_brief_correct):
@@ -3895,7 +3883,7 @@ class TestCancelBrief(BaseApplicationTest):
         self.data_api_client.cancel_brief.assert_not_called()
 
     @pytest.mark.parametrize('status', ['cancel', 'unsuccessful'])
-    def test_redirect_on_successful_status_change(self, status):
+    def test_redirect_and_flash_on_successful_status_change(self, status):
         res = self.client.post(
             self.url.format(brief_id=123), data={'cancel_reason': status}
         )
@@ -3905,18 +3893,7 @@ class TestCancelBrief(BaseApplicationTest):
 
         assert res.status_code == 302
         assert expected_url in redirect_text
-        self.assert_flashes("updated-brief", "message")
-
-    def test_flash_message_shown_on_brief_cancel(self):
-
-        with self.client.session_transaction() as session:
-            session['_flashes'] = [
-                ('message', {'updated-brief': "My Amazing Brief"})
-            ]
-        expected_url = '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-outcomes/123'
-        res = self.client.get(expected_url)
-        flash_div = html.fromstring(res.get_data(as_text=True)).xpath('//div[@class="banner-success-without-action"]')
-        assert flash_div[0].text_content().strip() == "You've updated 'My Amazing Brief'"
+        self.assert_flashes("You've updated 'I need a thing to do a thing'", "message")
 
 
 class TestBuyerAccountOverview(BaseApplicationTest):
@@ -4056,7 +4033,7 @@ class TestAwardOrCancelBrief(BaseApplicationTest):
         self.login_as_buyer()
         self.client.post(self.url.format(brief_id=self.brief['id']), data={'award_or_cancel_decision': 'back'})
 
-        self.assert_flashes("updated-brief")
+        self.assert_flashes("You've updated 'I need a thing to do a thing'", "message")
 
     def test_random_post_data_triggers_invalid_choice(self):
         self.login_as_buyer()


### PR DESCRIPTION
Flash messages moving out of templates and into Python code. I've taken the opportunity to make them have nice curly quotes, too.

Also moving some shared test login code into dm-test-utils.

https://trello.com/c/lQIP4rf8/300-flash-messages-briefs-app