### PR TITLE
Add hidden text for screen readers on ambiguous Edit links

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -85,7 +85,12 @@
             {{ summary.field_heading_date("Before {}".format(dates.questions_close | shortdateformat), rowspan='3', scope='row') }}
             {{ summary.text_bold("Details of your question and answer session") }}
             {% if not published %}
-              {{ summary.edit_link("Edit", url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id)) }}
+              {{ summary.edit_link(
+                    "Edit",
+                    url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id),
+                    hidden_text="question and answer session details"
+                 )
+              }}
             {% endif %}
           {% endcall %}
           {% call summary.row(no_border=True) %}

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -69,7 +69,12 @@
                 Optional
               {% endcall %}
             {% elif not question.answer_required %}
-              {{ summary.edit_link("Edit", url_for("buyers.edit_brief_question", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id)) }}
+              {{ summary.edit_link(
+                   "Edit",
+                   url_for("buyers.edit_brief_question", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id),
+                   hidden_text=question.label
+                 )
+              }}
             {% else %}
               {% call summary.field() %}{% endcall %}
             {% endif %}


### PR DESCRIPTION
Trello: https://trello.com/c/sYJYKnK9/58-how-summary-tables-handle-their-links-means-pages-can-contain-multiple-links-with-duplicate-text

If there are multiple links on a page with the same text, it can be confusing for screen reader users. This PR adds context in hidden text spans for the following links:

- Edit links on the Brief description of work sections
![description-of-work](https://user-images.githubusercontent.com/3492540/37294635-29ee6b22-260e-11e8-8ff7-45962e500998.png)

- Editing the Q&A session details on the 'If you publish today, you must be aware of the following dates' page
![q-and-a-details](https://user-images.githubusercontent.com/3492540/37294091-fa03811e-260c-11e8-8a99-f3c2231be3af.png)

See previous PRs for Brief Responses, Admin and Supplier FEs:
https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/32
https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/804
https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/367