### PR TITLE
add banner to account page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
 //= require _analytics.js'
 //= require _onready.js'
 //= require _selection-buttons.js

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -31,6 +31,7 @@ $path: "/static/images/";
 @import "toolkit/_phase-banner.scss";
 @import "toolkit/_proposition-header.scss";
 @import "toolkit/_secondary-action-link.scss";
+@import "toolkit/_user-research-consent-banner.scss";
 @import "toolkit/forms/_dates.scss";
 @import "toolkit/forms/_hint.scss";
 @import "toolkit/forms/_list-entry.scss";

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -14,7 +14,41 @@
   {% endwith %}
 {% endblock %}
 
+{% block head %}
+  {{ super() }}
+  {% if not current_user.user_research_opted_in and not 'seen_user_research_message' in request.cookies %}
+    {%
+      with
+      custom_dimensions = [
+        {
+          "data_id": 12,
+          "data_value": "User research banner"
+        }
+      ]
+    %}
+      {% include "toolkit/custom-dimensions.html" %}
+    {% endwith %}
+  {% endif %}
+{% endblock %}
+
+{% block after_header %}
+  {% if not current_user.user_research_opted_in and not 'seen_user_research_message' in request.cookies %}
+    {% include "toolkit/user-research-consent-banner.html" %}
+  {% endif %}
+{% endblock %}
+
 {% block main_content %}
+{% with messages = get_flashed_messages(with_categories=true, category_filter=["error", "success"]) %}
+  {% for category, message in messages %}
+    {%
+      with
+      message = message,
+      type = "destructive" if category == 'error' else "success"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  {% endfor %}
+{% endwith %}
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with
@@ -24,28 +58,47 @@
     {% include 'toolkit/page-heading.html' %}
     {% endwith %}
   </div>
+</div>
+<div class="grid-row">
   <div class="column-two-thirds dm-account-overview-options">
     
-  <div class="dmspeak">
-    <h2 class="heading-xmedium">Cloud hosting, software and support</h2>
-    <p>
-      {% if user_projects_total %}
-        <a href="/buyers/direct-award/g-cloud">View your saved searches</a><br>
-      {% else %}
-        You don't have any saved searches
-      {% endif %}
-    </p>
-  
-    <h2 class="heading-xmedium">Digital outcomes, specialists and user research participants</h2>
-    <p>
-      {% if user_briefs_total %}
-        <a href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>  
-      {% else %}   
-        You don't have any requirements
-      {% endif %}
-    </p>
-  </div>
+    <div class="dmspeak">
+      <h2 class="heading-xmedium">Cloud hosting, software and support</h2>
+      <p>
+        {% if user_projects_total %}
+          <a href="/buyers/direct-award/g-cloud">View your saved searches</a><br>
+        {% else %}
+          You don't have any saved searches
+        {% endif %}
+      </p>
+    
+      <h2 class="heading-xmedium">Digital outcomes, specialists and user research participants</h2>
+      <p>
+        {% if user_briefs_total %}
+          <a href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>  
+        {% else %}   
+          You don't have any requirements
+        {% endif %}
+      </p>
+    </div>
 
+  </div>
+  <div class="column-one-third dmspeak">
+    <h2 class="heading-xmedium">Account settings</h2>
+    <p>
+      <a 
+        href="{{ url_for('external.user_research_consent') }}"
+        data-analytics="trackEvent"
+        data-analytics-category="user-research"
+        data-analytics-action="account-settings-link"
+      >
+        {% if not current_user.user_research_opted_in %}
+          Join the user research mailing list
+        {% else %}
+          Unsubscribe from the user research mailing list
+        {% endif %}
+      </a>
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.10.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
   },

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,7 +36,7 @@ class BaseApplicationTest(object):
 
     @staticmethod
     def user(id, email_address, supplier_id, supplier_name, name,
-             is_token_valid=True, locked=False, active=True, role='buyer'):
+             is_token_valid=True, locked=False, active=True, role='buyer', userResearchOptedIn=True):
 
         hours_offset = -1 if is_token_valid else 1
         date = datetime.utcnow() + timedelta(hours=hours_offset)
@@ -49,7 +49,8 @@ class BaseApplicationTest(object):
             "role": role,
             "locked": locked,
             'active': active,
-            'passwordChangedAt': password_changed_at
+            'passwordChangedAt': password_changed_at,
+            'userResearchOptedIn': userResearchOptedIn
         }
 
         if supplier_id:
@@ -175,16 +176,18 @@ class BaseApplicationTest(object):
         response = self.client.get('/auto-supplier-login')
         assert response.status_code == 200
 
-    def login_as_buyer(self):
+    def login_as_buyer(self, user_researh_opted_in=True):
         with patch('app.data_api_client') as login_api_client:
 
             login_api_client.authenticate_user.return_value = self.user(
-                123, "buyer@email.com", None, None, u'Ā Buyer', role='buyer')
+                123, "buyer@email.com", None, None, u'Ā Buyer', role='buyer', userResearchOptedIn=user_researh_opted_in)
 
             self.get_user_patch = patch.object(
                 data_api_client,
                 'get_user',
-                return_value=self.user(123, "buyer@email.com", None, None, u'Ā Buyer', role='buyer')
+                return_value=self.user(
+                    123, "buyer@email.com", None, None, u'Ā Buyer', role='buyer',
+                    userResearchOptedIn=user_researh_opted_in)
             )
             self.get_user_patch.start()
 

--- a/tests/main/views/test_notifications.py
+++ b/tests/main/views/test_notifications.py
@@ -1,0 +1,54 @@
+from ...helpers import BaseApplicationTest
+import mock
+
+
+@mock.patch('app.main.views.buyers.data_api_client', autospec=True)
+class TestUserResearch(BaseApplicationTest):
+    def setup_method(self, method):
+        super(TestUserResearch, self).setup_method(method)
+
+    def test_should_see_banner_if_not_subscribed(
+        self, data_api_client
+    ):
+        with self.app.test_client():
+            self.login_as_buyer(user_researh_opted_in=False)
+            res = self.client.get('/buyers')
+            assert res.status_code == 200
+            assert 'Help us improve the Digital Marketplace' in res.get_data(as_text=True)
+            assert 'Sign up to be a potential user research participant' in res.get_data(as_text=True)
+            assert 'class="user-research-banner-close-btn"' in res.get_data(as_text=True)
+            cookie_value = self.get_cookie_by_name(res, 'seen_user_research_message')
+            assert cookie_value is None
+
+    def test_should_not_see_banner_if_subscribed(
+        self, data_api_client
+    ):
+        with self.app.test_client():
+            self.login_as_buyer(user_researh_opted_in=True)
+            res = self.client.get('/buyers')
+            assert res.status_code == 200
+            assert 'Help us improve the Digital Marketplace' not in res.get_data(as_text=True)
+            assert 'Sign up to be a potential user research participant' not in res.get_data(as_text=True)
+            assert 'class="user-research-banner-close-btn"' not in res.get_data(as_text=True)
+
+    def test_should_see_subscribed_link_if_not_subscribed(
+        self, data_api_client
+    ):
+        with self.app.test_client():
+            self.login_as_buyer(user_researh_opted_in=False)
+            res = self.client.get('/buyers')
+            assert res.status_code == 200
+            assert "href=\"/user/notifications/user-research\"" in res.get_data(as_text=True)
+            assert "Join the user research mailing list" in res.get_data(as_text=True)
+            assert "Unsubscribe from the user research mailing list" not in res.get_data(as_text=True)
+
+    def test_should_see_unsubscribed_link_if_subscribed(
+        self, data_api_client
+    ):
+        with self.app.test_client():
+            self.login_as_buyer(user_researh_opted_in=True)
+            res = self.client.get('/buyers')
+            assert res.status_code == 200
+            assert "href=\"/user/notifications/user-research\"" in res.get_data(as_text=True)
+            assert "Join the user research mailing list" not in res.get_data(as_text=True)
+            assert "Unsubscribe from the user research mailing list" in res.get_data(as_text=True)

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d68e13e0855d18a6e08edcc6ab6738d9ce267ae2"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.2.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.10.1":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#ba6f1db4f0960feff221f23e0bb0c86b44a1756c"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#f7fa5abe9c4d7c3025c8f2b91995304e0610a168"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
PRE REQUISITE:  https://github.com/alphagov/digitalmarketplace-user-frontend/pull/43

Add the user research banner to the account page using the existing GOV.uk pattern. Allow for links to 'sign up to mailing list' page

As a user I should be presented with the banner to sign up to the user research mailing list when I log in if: I have not already closed it and I have not already signed up for this.
This is the first point of contact for getting users to sign up to the mailing list.

The close link should set a cookie value of 'seen_this_banner_thing' to true so we don't show it again
The sign up link should link to the new sign up page.

https://trello.com/c/OJ9lFk1M/129-add-banner-to-account-page

<img width="994" alt="screen shot 2018-03-13 at 14 42 48" src="https://user-images.githubusercontent.com/4599889/37348827-f6050a0e-26cc-11e8-8c5b-c687478b4f4e.png">
