### PR TITLE
Remove old notification-banner template for flash messages

### DIFF
--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -55,19 +55,7 @@
         </div>
       {% endif %}
 
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          {% for category, message in messages %}
-            {%
-            with
-            message = message,
-            type = "destructive-without-action" if category == "error" else "success"
-            %}
-              {% include "toolkit/notification-banner.html" %}
-            {% endwith %}
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
+      {% include "toolkit/flash_messages.html" %}
     {% endblock %}
   </div>
 

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -15,21 +15,7 @@
 
     <div class="grid-row">
         <div class="column-one-whole">
-            {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                    {% for category, message in messages %}
-                        {% if category == 'error' %}
-                            <div class="banner-destructive-without-action">
-                        {% else %}
-                            <div class="banner-success-without-action">
-                        {% endif %}
-                                <p class="banner-message">
-                                    {{ message }}
-                                </p>
-                            </div>
-                    {% endfor %}
-                {% endif %}
-            {% endwith %}
+            {% include "toolkit/flash_messages.html" %}
         </div>
         <div class="column-two-thirds">
             {% with heading = "Your requirements" %}

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -38,17 +38,7 @@
 {% endblock %}
 
 {% block main_content %}
-{% with messages = get_flashed_messages(with_categories=true, category_filter=["error", "success"]) %}
-  {% for category, message in messages %}
-    {%
-      with
-      message = message,
-      type = "destructive" if category == 'error' else "success"
-    %}
-      {% include "toolkit/notification-banner.html" %}
-    {% endwith %}
-  {% endfor %}
-{% endwith %}
+{% include "toolkit/flash_messages.html" %}
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with


### PR DESCRIPTION
https://trello.com/c/ZUmDyovj/23-flash-messages-dry-etc

Cleaning up the leftover usages of `notification-banner.html` and replacing with `flash_messages.html` - this was missed from some of the original PRs.