### PR TITLE
digitalmarketplace-utils: bump to 36.2.2

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,8 +3,8 @@
 
 Flask==0.10.1
 Flask-Login==0.2.11
-Flask-WTF==0.12
+Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.1#egg=digitalmarketplace-utils==36.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.2#egg=digitalmarketplace-utils==36.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 
 Flask==0.10.1
 Flask-Login==0.2.11
-Flask-WTF==0.12
+Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.1#egg=digitalmarketplace-utils==36.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.2#egg=digitalmarketplace-utils==36.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 


### PR DESCRIPTION
Slight misunderstanding - the previous bump did *not* include the wtforms upgrade. this one does, and as such is the merge that must be released in sync with other frontends.