### PR TITLE
Move Briefs FE flash templates into base template

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -25,6 +25,7 @@
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">
+      {% include "toolkit/flash_messages.html" %}
       {% block main_content %}
       {% endblock %}
     </main>

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -54,8 +54,6 @@
           </form>
         </div>
       {% endif %}
-
-      {% include "toolkit/flash_messages.html" %}
     {% endblock %}
   </div>
 

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -14,9 +14,6 @@
 {% block main_content %}
 
     <div class="grid-row">
-        <div class="column-one-whole">
-            {% include "toolkit/flash_messages.html" %}
-        </div>
         <div class="column-two-thirds">
             {% with heading = "Your requirements" %}
             {% include 'toolkit/page-heading.html' %}

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -38,7 +38,6 @@
 {% endblock %}
 
 {% block main_content %}
-{% include "toolkit/flash_messages.html" %}
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with


### PR DESCRIPTION
Epic: https://trello.com/c/5pZdW4Cb/122-centralise-frontend-header-footer-templates

Currently the templates include `toolkit/flash_messages.html` in a couple of different places.

Moving it to the base template has previously caused weird whitespace issues - these should be easier to sort out now we've moved out some analytics logic from the templates.

Ideally the Briefs FE base template should be consistent with the other FE apps.

Ticket: https://trello.com/c/0q1xiDvF/47-move-briefs-fe-flash-templates-into-base-template