### PR TITLE
Instrument GA tracking to capture clicks made on external links

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.14.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.14.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d68e13e0855d18a6e08edcc6ab6738d9ce267ae2"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.14.0":
-  version "28.14.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#14a54cacb3edaa255d04c5a41ef71e0facf64e92"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#28.14.1":
+  version "28.14.1"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#6d0ac0fdb5a6f81bc3647629fb1512d299109419"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Removes wrapper function in favour of a direct call to GOVUK function. This is required as wrapper function is not available in all apps.

====
A lot of GA tracking comes 'out of the box' but a notable exception is tracking to capture clicks on external links. Additional code is required in order to capture these.

Currently, we are tracking some external links on the DM site (those that were specifically required for previous mission work).

The proposal is to have all external links tracked automatically across the whole site, similar to how GOV.UK have done.

The advantage of doing this is that we have key data available straight away at the start of mission teams rather than having to prioritise the work, use up dev resource and then wait for enough data to populate before being able to carry out analysis.

---> includes making sure all links on the homepage are tracked, so we can measure which links are used the most and least.

https://trello.com/c/GU1raroG/57-instrument-ga-tracking-to-capture-clicks-made-on-external-links