### PR TITLE
Rename framework_framework variable

### DIFF
--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -23,7 +23,7 @@
             {% include 'toolkit/page-heading.html' %}
           {% endwith %}
             <p>
-              <a href="{{ url_for('external.get_brief_by_id', framework_framework=brief.frameworkFramework, brief_id=brief.id) }}">View the outcome of the requirements</a>
+              <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id) }}">View the outcome of the requirements</a>
             </p>
       {% else %}
         {% with

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -115,7 +115,7 @@
                   'allowed_statuses': ['live']
                 },
                 {
-                  'href': url_for("external.get_brief_by_id", framework_framework=brief.frameworkFramework, brief_id=brief.id),
+                  'href': url_for("external.get_brief_by_id", framework_family=brief.frameworkFramework, brief_id=brief.id),
                   'text': 'View your published requirements',
                   'allowed_statuses': ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful']
                 }

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -106,7 +106,7 @@
             </form>
           {% endcall %}
         {% elif item.status == "withdrawn" %}
-          {{ summary.service_link(item.title, url_for("external.get_brief_by_id", framework_framework=item.frameworkFramework, brief_id=item.id)) }}
+          {{ summary.service_link(item.title, url_for("external.get_brief_by_id", framework_family=item.frameworkFramework, brief_id=item.id)) }}
           {{ summary.text("Withdrawn") }}
           {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {% elif item.status in ["awarded", "cancelled", "unsuccessful"] %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@37.0.0#egg=digitalmarketplace-utils==37.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@38.0.0#egg=digitalmarketplace-utils==38.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@37.0.0#egg=digitalmarketplace-utils==37.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@38.0.0#egg=digitalmarketplace-utils==38.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 


### PR DESCRIPTION
 ## Summary
`framework_framework` is an unnecessarily obtuse variable name and is
not overly descriptive of what it actually means. When used, this
describes the 'family' of framework being referenced. For example,
G-Cloud 10 is in the 'G-Cloud' family of frameworks. Digital Outcomes
and Specialists 2 is in the 'Digital Outcomes and Specialists' family.
Let's change all the references of `framework_framework` to
`framework_family`.

 ## Ticket
https://trello.com/c/iqFcVKpd/14

 ## Dependencies
https://github.com/alphagov/digitalmarketplace-utils/pull/397