### PR TITLE
Refactor validation masthead use

### DIFF
--- a/app/create_buyer/views/create_buyer.py
+++ b/app/create_buyer/views/create_buyer.py
@@ -2,6 +2,7 @@ from flask import current_app, render_template, url_for, redirect, session, Blue
 
 from dmapiclient.audit import AuditTypes
 from dmutils.email import send_user_account_email
+from dmutils.forms import get_errors_from_wtform
 
 from app import data_api_client
 
@@ -47,6 +48,7 @@ def submit_create_buyer_account():
         return render_template(
             "create_buyer/create_buyer_account.html",
             form=form,
+            errors=get_errors_from_wtform(form),
             email_address=form.email_address.data
         ), 400
 

--- a/app/main/views/outcome.py
+++ b/app/main/views/outcome.py
@@ -14,6 +14,7 @@ from ..forms.cancel import CancelBriefForm
 from ..forms.award_or_cancel import AwardOrCancelBriefForm
 
 from dmapiclient import HTTPError
+from dmutils.forms import get_errors_from_wtform
 
 BRIEF_UPDATED_MESSAGE = "You’ve updated ‘{brief[title]}’"
 
@@ -55,10 +56,7 @@ def award_or_cancel_brief(framework_slug, lot_slug, brief_id):
         if request.method == "POST":
             form = AwardOrCancelBriefForm(brief, request.form)
             if not form.validate_on_submit():
-                errors = {
-                    key: {'question': form[key].label.text, 'input_name': key, 'message': form[key].errors[0]}
-                    for key, value in form.errors.items()
-                }
+                errors = get_errors_from_wtform(form)
             else:
                 answer = form.data.get('award_or_cancel_decision')
                 if answer == 'back':
@@ -127,12 +125,11 @@ def award_brief(framework_slug, lot_slug, brief_id):
     if request.method == "POST":
         form = AwardedBriefResponseForm(brief_responses, request.form)
         if not form.validate_on_submit():
-            form_errors = [{'question': form[key].label.text, 'input_name': key} for key in form.errors]
             return render_template(
                 "buyers/award.html",
                 brief=brief,
                 form=form,
-                form_errors=form_errors,
+                errors=get_errors_from_wtform(form),
                 breadcrumbs=breadcrumbs,
             ), 400
 
@@ -164,6 +161,7 @@ def award_brief(framework_slug, lot_slug, brief_id):
         "buyers/award.html",
         brief=brief,
         form=form,
+        errors=get_errors_from_wtform(form),
         breadcrumbs=breadcrumbs,
     ), 200
 
@@ -213,10 +211,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
     if request.method == "POST":
         form = CancelBriefForm(brief, label_text, request.form)
         if not form.validate_on_submit():
-            errors = {
-                key: {'question': form[key].label.text, 'input_name': key, 'message': form[key].errors[0]}
-                for key, value in form.errors.items()
-            }
+            errors = get_errors_from_wtform(form)
         else:
             new_status = form.data.get('cancel_reason')
             try:

--- a/app/main/views/outcome.py
+++ b/app/main/views/outcome.py
@@ -192,7 +192,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
         abort(404)
 
     if award_flow:
-        label_text = "Why didn't you award a contract for {}?"
+        label_text = "Why didn’t you award a contract for {}?"
         previous_page_url = url_for(
             '.award_or_cancel_brief',
             framework_slug=brief['frameworkSlug'],

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -22,11 +22,7 @@
     </div>
   </div>
 
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
+  {% include 'toolkit/forms/validation.html' %}
 
   <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
 

--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -11,6 +11,7 @@
 {% endblock %}
 
 {% block main_content %}
+{% include 'toolkit/forms/validation.html' %}
 <div class="grid-row">
     <div class="column-two-thirds">
           <div class="single-question-page">
@@ -37,7 +38,7 @@
                       type = "radio",
                       options = form.brief_response.toolkit_macro_options,
                       value = form.brief_response.data,
-                      error = form.brief_response.errors[0]
+                      error = errors.get('brief_response', {}).get('message', None)
                     %}
                       {% include "toolkit/forms/selection-buttons.html" %}
                     {% endwith %}

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -13,11 +13,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
+  {% include 'toolkit/forms/validation.html' %}
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -11,11 +11,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
+  {% include 'toolkit/forms/validation.html' %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <div class="single-question-page">

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -13,11 +13,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
+  {% include 'toolkit/forms/validation.html' %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <div class="single-question-page">

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -18,20 +18,9 @@
 
 {% block main_content %}
 
-{% if form.errors %}
-    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with the details you gave for:
-        </h3>
-        <ul>
-        {% for field_name, field_errors in form.errors|dictsort if field_errors %}
-        {% for error in field_errors %}
-          <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
-        {% endfor %}
-        {% endfor %}
-        </ul>
-    </div>
-{% endif %}
+{% with lede = "There was a problem with the details you gave for:" %}
+  {% include "toolkit/forms/validation.html" %}
+{% endwith %}
 
 {%
   with

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
   },

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.1#egg=digitalmarketplace-utils==36.10.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@37.0.0#egg=digitalmarketplace-utils==37.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.1#egg=digitalmarketplace-utils==36.10.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@37.0.0#egg=digitalmarketplace-utils==37.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -462,7 +462,7 @@ class TestCancelBrief(BaseApplicationTest):
 
         document = html.fromstring(res.get_data(as_text=True))
         page_title = document.xpath('//h1')[0].text_content()
-        assert "Why didn't you award a contract for {}?".format(self.brief.get('title')) in page_title
+        assert "Why didn’t you award a contract for {}?".format(self.brief.get('title')) in page_title
 
         submit_button = document.xpath('//input[@class="button-save" and @value="Update requirements"]')
         assert len(submit_button) == 1

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -141,6 +141,10 @@ class TestAwardBrief(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         assert res.status_code == 400
+
+        validation_message = document.xpath('//span[@class="validation-message"]')[0].text_content()
+        assert validation_message.strip() == "You need to answer this question."
+
         error_span = document.xpath('//span[@id="error-brief_response"]')[0]
         assert self._strip_whitespace(error_span.text_content()) == "Youneedtoanswerthisquestion."
 
@@ -151,6 +155,10 @@ class TestAwardBrief(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         assert res.status_code == 400
+
+        validation_message = document.xpath('//span[@class="validation-message"]')[0].text_content()
+        assert validation_message.strip() == "Not a valid choice"
+
         error_span = document.xpath('//span[@id="error-brief_response"]')[0]
         assert self._strip_whitespace(error_span.text_content()) == "Notavalidchoice"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d68e13e0855d18a6e08edcc6ab6738d9ce267ae2"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0":
-  version "28.15.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#05167f7a96843fe3e893448a64770ec9dd01684c"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0":
+  version "29.0.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87b8535689b160c26c0ac53d9d6bb96cde10c277"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
 ## Summary
We have an updated version of the validation masthead for pages
displaying errors with form submissions that abstracts some more of the
responsibility from the individual templates and supports our main error
formats natively (content loader forms and wtforms). This means we can
rip out some of the boilerplate from our templates.

There's also a page here that didn't use the validation masthead from
the frontend-toolkit which has now been brought in line.

 ## Ticket
https://trello.com/c/RSYEM3FL/448
