### PR TITLE
Iterate opt in flow for user research participants

### DIFF
--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -14,29 +14,6 @@
   {% endwith %}
 {% endblock %}
 
-{% block head %}
-  {{ super() }}
-  {% if not current_user.user_research_opted_in and not 'seen_user_research_message' in request.cookies %}
-    {%
-      with
-      custom_dimensions = [
-        {
-          "data_id": 12,
-          "data_value": "User research banner"
-        }
-      ]
-    %}
-      {% include "toolkit/custom-dimensions.html" %}
-    {% endwith %}
-  {% endif %}
-{% endblock %}
-
-{% block after_header %}
-  {% if not current_user.user_research_opted_in and not 'seen_user_research_message' in request.cookies %}
-    {% include "toolkit/user-research-consent-banner.html" %}
-  {% endif %}
-{% endblock %}
-
 {% block main_content %}
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d68e13e0855d18a6e08edcc6ab6738d9ce267ae2"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0":
-  version "29.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87b8535689b160c26c0ac53d9d6bb96cde10c277"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.0":
+  version "31.0.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#f0b6e4ce678ac7257f187e3b5bb43a0c143b4694"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
**As a buyer I want to easily opt-in to user research so that I can help improve the buyer experience for G-Cloud**

The current opt-in journey has been unsuccessful, only 6 buyers have signed up. A higher number of suppliers, however, we suspect that this is due to G10 submission going on at the same time.

Buyer and suppliers cannot opt-in until they log in. Buyers and suppliers that don't log in don't have an opportunity to opt-in for user research.

***

**Changes**

Cookie banner to appear on all pages for logged in and logged out users until they click close or opt in. If clicked close, it reappears after 90 days.

***

**Notes**

Users will have to log in before they can opt-in.
We should use the existing opt-in journey as much as possible. This is non-mission work.

Ticket: https://trello.com/c/48pZNhaG/120-iterate-opt-in-flow-for-user-research-participants