### PR TITLE
Update frontend-toolkit to v31.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d68e13e0855d18a6e08edcc6ab6738d9ce267ae2"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.0":
-  version "31.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#f0b6e4ce678ac7257f187e3b5bb43a0c143b4694"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1":
+  version "31.0.1"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b34e87bf0c1910f6c8d4ef86f1db9b6533423902"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Includes user research banner CSS tweaks from https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/446