### PR TITLE
buyer_dashboard: include message if user has projects awaiting outcome information

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -28,13 +28,22 @@ BRIEF_WITHDRAWN_MESSAGE = "You’ve withdrawn your requirements for ‘{brief[ti
 
 @main.route('')
 def buyer_dashboard():
-    user_briefs_total = len(data_api_client.find_briefs(current_user.id).get('briefs', []))
-    user_projects_total = len(data_api_client.find_direct_award_projects(current_user.id).get('projects', []))
+    user_projects_awaiting_outcomes_total = data_api_client.find_direct_award_projects(
+        current_user.id,
+        locked=True,
+        having_outcome=False,
+    )["meta"]["total"]
 
     return render_template(
         'buyers/index.html',
-        user_briefs_total=user_briefs_total,
-        user_projects_total=user_projects_total
+        user_briefs_total=data_api_client.find_briefs(current_user.id)["meta"]["total"],
+        user_projects_awaiting_outcomes_total=user_projects_awaiting_outcomes_total,
+        # calculating it this way allows us to avoid the extra api call if we already know the user has projects
+        # from user_projects_awaiting_outcomes_total
+        user_has_projects=bool(
+            user_projects_awaiting_outcomes_total
+            or data_api_client.find_direct_award_projects(current_user.id)["meta"]["total"]
+        ),
     )
 
 

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -31,10 +31,14 @@
     <div class="dmspeak">
       <h2 class="heading-xmedium">Cloud hosting, software and support</h2>
       <p>
-        {% if user_projects_total %}
+        {% if user_has_projects %}
+          {% if user_projects_awaiting_outcomes_total %}
+            You need to tell us the outcome for {{ user_projects_awaiting_outcomes_total }}
+            {{ pluralize(user_projects_awaiting_outcomes_total, "saved search", "saved searches") }}.<br>
+          {% endif %}
           <a href="/buyers/direct-award/g-cloud">View your saved searches</a><br>
         {% else %}
-          You don't have any saved searches
+          You don't have any saved searches.
         {% endif %}
       </p>
     
@@ -43,7 +47,7 @@
         {% if user_briefs_total %}
           <a href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>  
         {% else %}   
-          You don't have any requirements
+          You don't have any requirements.
         {% endif %}
       </p>
     </div>

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.1.0#egg=digitalmarketplace-apiclient==17.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.1.0#egg=digitalmarketplace-apiclient==17.1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -48,6 +48,7 @@ s3transfer==0.1.13
 six==1.11.0
 unicodecsv==0.14.1
 urllib3==1.22
+virtualenv==15.1.0
 Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.2.1

--- a/tests/fixtures/dos_brief_fixture.json
+++ b/tests/fixtures/dos_brief_fixture.json
@@ -24,7 +24,7 @@
       "provide a case study or evidence of previous work"
     ],
     "existingTeam": "Key stakeholders within Border Force",
-    "frameworkFramework": "digital-outcomes-and-specialists",
+    "frameworkFamily": "digital-outcomes-and-specialists",
     "frameworkName": "Digital Outcomes and Specialists 2",
     "frameworkSlug": "digital-outcomes-and-specialists-2",
     "frameworkStatus": "live",

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -15,7 +15,7 @@
       "evaluationType": [
         "Interview"
       ],
-      "frameworkFramework":"digital-outcomes-and-specialists",
+      "frameworkFamily":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists",
       "frameworkSlug":"digital-outcomes-and-specialists",
       "frameworkStatus":"live",
@@ -70,7 +70,7 @@
         "provide a case study or evidence of previous work",
         "presentation"
       ],
-      "frameworkFramework":"digital-outcomes-and-specialists",
+      "frameworkFamily":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists 2",
       "frameworkSlug":"digital-outcomes-and-specialists-2",
       "frameworkStatus":"live",

--- a/tests/main/helpers/test_buyers_helpers.py
+++ b/tests/main/helpers/test_buyers_helpers.py
@@ -5,7 +5,7 @@ from werkzeug.exceptions import NotFound
 import app.main.helpers as helpers
 from dmcontent.content_loader import ContentLoader
 
-from dmapiclient import api_stubs
+from dmutils import api_stubs
 
 content_loader = ContentLoader('tests/fixtures/content')
 content_loader.load_manifest('dos', 'data', 'edit_brief')
@@ -14,13 +14,12 @@ questions_builder = content_loader.get_manifest('dos', 'edit_brief')
 
 class TestBuyersHelpers(object):
     def test_get_framework_and_lot(self):
+        provided_lot = api_stubs.lot(slug='digital-specialists', allows_brief=True)
         data_api_client = mock.Mock()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug='digital-outcomes-and-specialists',
             status='live',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True)
-            ]
+            lots=[provided_lot],
         )
 
         framework, lot = helpers.buyers_helpers.get_framework_and_lot('digital-outcomes-and-specialists',
@@ -31,12 +30,7 @@ class TestBuyersHelpers(object):
         assert framework['name'] == 'Digital Outcomes and Specialists'
         assert framework['slug'] == 'digital-outcomes-and-specialists'
         assert framework['clarificationQuestionsOpen'] is True
-        assert lot == {'slug': 'digital-specialists',
-                       'oneServiceLimit': False,
-                       'allowsBrief': True,
-                       'id': 1,
-                       'name': 'Digital Specialists',
-                       }
+        assert lot == provided_lot
 
     def test_get_framework_and_lot_404s_for_wrong_framework_status(self):
         data_api_client = mock.Mock()

--- a/tests/main/views/test_digital_outcomes_and_specialists.py
+++ b/tests/main/views/test_digital_outcomes_and_specialists.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from ...helpers import BaseApplicationTest
-from dmapiclient import api_stubs
+from dmutils import api_stubs
 import mock
 from lxml import html
 

--- a/tests/main/views/test_download_responses.py
+++ b/tests/main/views/test_download_responses.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from ...helpers import BaseApplicationTest
-from dmapiclient import api_stubs
+from dmutils import api_stubs
 from dmcontent.content_loader import ContentLoader
 from dmcontent.questions import Question
 import mock

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 
 from ...helpers import BaseApplicationTest
-from dmapiclient import api_stubs, HTTPError
+from dmapiclient import HTTPError
+from dmutils import api_stubs
 import mock
 from lxml import html
 import pytest

--- a/tests/main/views/test_supplier_questions.py
+++ b/tests/main/views/test_supplier_questions.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 
 from ...helpers import BaseApplicationTest
-from dmapiclient import api_stubs, HTTPError
+from dmapiclient import HTTPError
+from dmutils import api_stubs
 import mock
 from lxml import html
 import pytest


### PR DESCRIPTION
Trello https://trello.com/c/4Ub332Ty/70-fe-7-you-need-to-tell-us-the-outcome-for-1-saved-search-to-be-added-dynamic

I seem to have unconsciously added a full stop to the end of the sentence - @karlchillmaid is this desired or not?

![after](https://user-images.githubusercontent.com/807447/41916744-99d95ee8-7950-11e8-8467-6a6df67868a9.png)
