### PR TITLE
Update frameworks to 13.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.1.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.2.0"
   },
   "scripts": {
     "test": "./node_modules/gulp/bin/gulp.js test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,9 +515,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.1.0":
-  version "13.1.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d51ee0b7c1751b0d08d6ddf14bd64d12b9783f57"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.2.0":
+  version "13.2.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#6c3cd8d90b9cc2641ee6d99c26c3f814686c840a"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1":
   version "31.0.1"


### PR DESCRIPTION
This is to fix an [issue][trello] where the links for the DOS
"standard contract" was incorrect for DOS2.

[trello]: https://trello.com/c/TujeCS5C

---

## Side by side
![before](https://trello-attachments.s3.amazonaws.com/59d211ac833af9fc1dc498b6/5b4c9593d5a9c9354a94b234/1022x653/e50e003edad571ab42e60ffe824bf94d/wXu81K5qTq.gif)
![after](https://user-images.githubusercontent.com/503614/42767499-1aadc490-8915-11e8-9dc2-4615bffc3203.gif)
