### PR TITLE
Use framework.family instead of frameworkFramework

### DIFF
--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -23,7 +23,7 @@
             {% include 'toolkit/page-heading.html' %}
           {% endwith %}
             <p>
-              <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id) }}">View the outcome of the requirements</a>
+              <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">View the outcome of the requirements</a>
             </p>
       {% else %}
         {% with

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -115,7 +115,7 @@
                   'allowed_statuses': ['live']
                 },
                 {
-                  'href': url_for("external.get_brief_by_id", framework_family=brief.frameworkFramework, brief_id=brief.id),
+                  'href': url_for("external.get_brief_by_id", framework_family=brief.framework.family, brief_id=brief.id),
                   'text': 'View your published requirements',
                   'allowed_statuses': ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful']
                 }

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -106,7 +106,7 @@
             </form>
           {% endcall %}
         {% elif item.status == "withdrawn" %}
-          {{ summary.service_link(item.title, url_for("external.get_brief_by_id", framework_family=item.frameworkFramework, brief_id=item.id)) }}
+          {{ summary.service_link(item.title, url_for("external.get_brief_by_id", framework_family=item.framework.family, brief_id=item.id)) }}
           {{ summary.text("Withdrawn") }}
           {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {% elif item.status in ["awarded", "cancelled", "unsuccessful"] %}

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -16,8 +16,13 @@ from freezegun import freeze_time
 def find_briefs_mock():
     base_brief_values = {
         "createdAt": "2016-02-01T00:00:00.000000Z",
+        "framework": {
+            "slug": "digital-outcomes-and-specialists-2",
+            "family": "digital-outcomes-and-specialists",
+            "status": "live",
+            "name": "Digital Outcomes and Specialists 2"
+        },
         "frameworkSlug": "digital-outcomes-and-specialists-2",
-        "frameworkFramework": "digital-outcomes-and-specialists",
         "lot": "digital-specialists"
     }
 


### PR DESCRIPTION
Trello: https://trello.com/c/R3DsCXFa/22-use-frameworkfamily-frameworkfamily-in-apps-apiclient-rather-than-frameworkframework-frameworkframework

We need to use the nested `framework` object on the Brief to access the `family`.

I haven't changed the code to use the other fields in the `framework` object (`slug`, `name`, `status`) to keep this PR short and sweet. Migrating the apps to use those is definitely for another ticket!