### PR TITLE
Briefs FE errors: pass status code as kwarg

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -13,4 +13,4 @@ def api_error_handler(e):
 
 @main.app_errorhandler(QuestionNotFoundError)
 def content_loader_error_handler(e):
-    return render_error_page(400)
+    return render_error_page(status_code=400)


### PR DESCRIPTION
Fixes the same bug as for the Buyer FE: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/828. This one isn't out in prod yet though.

BAD:
```
render_error_page(400)
```

GOOD:
```
render_error_page(status_code=400)
```