### PR TITLE
18 flask 1x upgrade

### DIFF
--- a/app/main/forms/award_or_cancel.py
+++ b/app/main/forms/award_or_cancel.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import FlaskForm
+from flask_wtf import FlaskForm
 from wtforms import RadioField, validators
 
 

--- a/app/main/forms/awards.py
+++ b/app/main/forms/awards.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import FlaskForm
+from flask_wtf import FlaskForm
 from wtforms import RadioField, validators
 
 

--- a/app/main/forms/cancel.py
+++ b/app/main/forms/cancel.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import FlaskForm
+from flask_wtf import FlaskForm
 from wtforms import RadioField, validators
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.12.4
+Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,5 +6,5 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.12.4
+Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ chardet==3.0.4
 click==6.7
 contextlib2==0.4.0
 cryptography==2.3
-digitalmarketplace-utils==44.0.1
 docopt==0.4.0
 docutils==0.14
 Flask-Script==2.0.6
@@ -43,11 +42,11 @@ python-dateutil==2.7.3
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
-requests==2.18.4
+requests==2.19.1
 s3transfer==0.1.13
-six==1.10.0
+six==1.11.0
 unicodecsv==0.14.1
-urllib3==1.22
+urllib3==1.23
 Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,20 +6,21 @@ Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
-boto3==1.4.8
-botocore==1.8.50
+boto3==1.7.83
+botocore==1.10.84
 certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
 click==6.7
 contextlib2==0.4.0
 cryptography==2.3
+digitalmarketplace-utils==44.0.1
 docopt==0.4.0
 docutils==0.14
 Flask-Script==2.0.6
@@ -44,7 +45,7 @@ pytz==2015.4
 PyYAML==3.11
 requests==2.18.4
 s3transfer==0.1.13
-six==1.11.0
+six==1.10.0
 unicodecsv==0.14.1
 urllib3==1.22
 Werkzeug==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.9.0#egg=digitalmarketplace-content-loader==4.9.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0


### PR DESCRIPTION
Upgrade to flask 1.0.2

Change imports from deprecated flask.ext to flask_

> flask.ext - import extensions directly by their name instead of through the flask.ext namespace

http://flask.pocoo.org/docs/1.0/changelog/#version-1-0-2

https://trello.com/c/bBDir2Gp/18-flask-1x-upgrade