### PR TITLE
Load supplier lot csvs from correct framework s3 bucket

### DIFF
--- a/app/main/views/digital_outcomes_and_specialists.py
+++ b/app/main/views/digital_outcomes_and_specialists.py
@@ -11,10 +11,13 @@ from ..helpers.buyers_helpers import get_framework_and_lot
 @dos.route('/frameworks/<framework_slug>/requirements/user-research-studios', methods=['GET'])
 def studios_start_page(framework_slug):
     # Check framework is live and has the user-research-studios lot
-    get_framework_and_lot(framework_slug, 'user-research-studios', data_api_client, allowed_statuses=['live'])
+    framework, lot = get_framework_and_lot(
+        framework_slug, 'user-research-studios', data_api_client, allowed_statuses=['live']
+    )
 
     return render_template(
-        "buyers/studios_start_page.html"
+        "buyers/studios_start_page.html",
+        framework=framework,
     ), 200
 
 

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -40,20 +40,20 @@
     <div class="column-two-thirds large-paragraph">
         <div class="marketplace-paragraph">
                  {% set digital_specialists_intro %}
-                    <p>You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.</p> 
+                    <p>You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.</p>
                     <p>You need to write ‘requirements’ to describe the work and tell suppliers to provide a specialist. The specialist can’t work for you outside the scope of your written requirements.</p>
                 {% endset %}
-     
+
                  {% set digital_outcomes_intro %}
                     <p>You can use the Digital Marketplace to find a team to work on a digital outcome, such as a booking system or an accessibility audit.</p>
                     <p>You need to write ‘requirements’ to describe the situation or problem and ask suppliers to propose a solution and provide a team.</p>
                     <p>The members of the team can’t work for you outside the scope of your written requirements.</p>
                 {% endset %}
-                
+
                 {% set user_research_participants_intro %}
-                    <p>To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.</p>   
+                    <p>To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.</p>
                 {% endset %}
-            
+
                 {{
                     {
                     "digital-specialists": digital_specialists_intro,
@@ -66,7 +66,7 @@
         <h2>Before you start</h2>
         <ol class="list-number">
             <li>You can talk to suppliers to prepare your requirements.<br>
-                <a href="https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/communications/catalogues/{{ lot.slug }}-suppliers.csv">
+                <a href="https://assets.digitalmarketplace.service.gov.uk/{{ framework.slug }}/communications/catalogues/{{ lot.slug }}-suppliers.csv">
                     Download list of suppliers.
                 </a>
             </li>

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -75,7 +75,7 @@ Find a user research lab - Digital Marketplace
         <div class="marketplace-paragraph">
             <p>Read more about <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
         </div>
-        
+
         <h2>Download the list of labs</h2>
 
         {%
@@ -83,7 +83,7 @@ Find a user research lab - Digital Marketplace
             items = [
             {
             "title": "List of labs",
-            "link": "https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/communications/catalogues/user-research-studios.csv",
+            "link": "https://assets.digitalmarketplace.service.gov.uk/{}/communications/catalogues/user-research-studios.csv".format(framework.slug),
             "file_type": "csv"
             }
             ]
@@ -92,7 +92,7 @@ Find a user research lab - Digital Marketplace
         {% endwith %}
 
         <p>Get help filtering the list at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a></p>
-        
+
     </div>
 </div>
 

--- a/tests/main/views/test_digital_outcomes_and_specialists.py
+++ b/tests/main/views/test_digital_outcomes_and_specialists.py
@@ -1,10 +1,11 @@
 # coding: utf-8
-from __future__ import unicode_literals
+import mock
+
+import pytest
+from lxml import html
+from dmutils import api_stubs
 
 from ...helpers import BaseApplicationTest
-from dmutils import api_stubs
-import mock
-from lxml import html
 
 
 class TestStartBriefInfoPage(BaseApplicationTest):
@@ -34,6 +35,39 @@ class TestStartBriefInfoPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert document.xpath('//h1')[0].text_content().strip() == "Find an individual specialist"
+
+    @pytest.mark.parametrize(
+        ('slug_suffix', 'lot_slug'),
+        (
+            ('', 'digital-outcomes'),
+            ('', 'digital-specialists'),
+            ('', 'user-research-participants'),
+            ('-2', 'digital-outcomes'),
+            ('-2', 'digital-specialists'),
+            ('-2', 'user-research-participants'),
+            ('-3', 'digital-outcomes'),
+            ('-3', 'digital-specialists'),
+            ('-3', 'user-research-participants'),
+        )
+    )
+    def test_has_correct_link_to_supplier_csv(self, slug_suffix, lot_slug):
+        self.data_api_client.get_framework.return_value = api_stubs.framework(
+            slug=f'digital-outcomes-and-specialists{slug_suffix}',
+            status='live',
+            lots=[
+                api_stubs.lot(slug=lot_slug, allows_brief=True),
+            ]
+        )
+        res = self.client.get(
+            f"/buyers/frameworks/digital-outcomes-and-specialists{slug_suffix}/requirements/{lot_slug}"
+        )
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+        assert document.xpath("//a[normalize-space()='Download list of suppliers.']")[0].attrib['href'] == (
+            f"https://assets.digitalmarketplace.service.gov.uk/"
+            f"digital-outcomes-and-specialists{slug_suffix}/communications/catalogues/{lot_slug}-suppliers.csv"
+        )
 
     def test_404_if_lot_does_not_allow_brief(self):
         self.data_api_client.get_framework.return_value = api_stubs.framework(
@@ -89,6 +123,27 @@ class TestStartStudiosInfoPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert document.xpath('//h1')[0].text_content().strip() == "Find a user research lab"
+
+    @pytest.mark.parametrize(('slug_suffix'), ('', '-2', '-3'))
+    def test_has_correct_link_to_supplier_csv(self, slug_suffix):
+        self.data_api_client.get_framework.return_value = api_stubs.framework(
+            slug=f'digital-outcomes-and-specialists{slug_suffix}',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='user-research-studios', allows_brief=True),
+            ]
+        )
+        res = self.client.get(
+            f"/buyers/frameworks/digital-outcomes-and-specialists{slug_suffix}/requirements/user-research-studios"
+        )
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.xpath("//a[@class='document-link-with-icon']")[0].attrib['href'] == (
+            f"https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists{slug_suffix}"
+            f"/communications/catalogues/user-research-studios.csv"
+        )
 
     def test_404_if_framework_status_is_not_live(self):
         self.data_api_client.get_framework.return_value = api_stubs.framework(


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/6flmLBWC)

The csvs of suppliers by lot were being loaded from the original DOS
framework bucket location, regardless of the framework iteration. This is weird
and confusing and this fixes that.

The files have been copied to the DOS2 bucket, ready for this change. The new files for DOS3 will be generated and uploaded soon. Tomorrow.