### PR TITLE
Update test dependencies

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -484,9 +484,11 @@ def publish_brief(framework_slug, lot_slug, brief_id):
     else:
         #  requirements length is a required question but is handled separately to other
         #  required questions on the publish page if it's unanswered.
-        if sections.get_section('set-how-long-your-requirements-will-be-open-for') and \
-                sections.get_section('set-how-long-your-requirements-will-be-open-for').questions[0].answer_required:
-                unanswered_required -= 1
+        if (
+            sections.get_section('set-how-long-your-requirements-will-be-open-for') and
+            sections.get_section('set-how-long-your-requirements-will-be-open-for').questions[0].answer_required
+        ):
+            unanswered_required -= 1
 
         email_address = brief_users['emailAddress']
         dates = get_publishing_dates(brief)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,14 @@
 -r requirements.txt
 
 #Required for testing
-pytest==4.1.1
+pytest==4.2.0
 mock==2.0.0
 lxml==4.3.0
 cssselect==1.0.3
 watchdog==0.9.0
 freezegun==0.3.11
-flake8==3.6.0
+flake8==3.7.4
 coverage==4.5.2
-flake8-per-file-ignores==0.7
 pytest-cov==2.6.1
 python-coveralls==2.9.1
 


### PR DESCRIPTION
Supersedes the current open PyUp PRs for this repo.

`flake8` now supports per-file-ignores well enough for our purposes. This means we can remove the extra `flake8-per-file-ignores` dependency.  

The new version of flake8 suggested one indenting change, which I agreed with.