### PR TITLE
DOS4: change assessment methods selector in brief creation process

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,12 +7,24 @@ let
     forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
+  sitePrioNonNix = args.pkgs.writeTextFile {
+    name = "site-prio-non-nix";
+    destination = "/${args.pythonPackages.python.sitePackages}/sitecustomize.py";
+    text = ''
+      import sys
+      first_nix_i = next((i for i, p in enumerate(sys.path) if p.startswith("/nix/")), 1)
+      # after the first nix-provided path in sys.path (presumably the python stdlib itself), re-sort all non-nix
+      # paths to be before the nix paths. this is helped by python's sort being a stable-sort
+      sys.path[first_nix_i+1:] = sorted(sys.path[first_nix_i+1:], key=lambda p: p.startswith("/nix/"))
+    '';
+  };
 in (with args; {
   digitalMarketplaceBriefsFrontendEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-briefs-frontend-env";
     shortName = "dm-brf-fe";
     buildInputs = [
       pythonPackages.python
+      sitePrioNonNix
       pkgs.glibcLocales
       pkgs.nodejs-8_x
       pkgs.yarn

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.10"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.1.0"
   },
   "scripts": {
     "test": "./node_modules/gulp/bin/gulp.js test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,9 +814,9 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.10":
-  version "16.0.10"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#960bc2709719ee31e77a5bbe4503de6a846d23ae"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#16.1.0":
+  version "16.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#83c5ccce9884ca354ffc4899aff96f0c3e93e07a"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.0":
   version "33.0.0"


### PR DESCRIPTION
https://trello.com/c/S1kIwe05

See https://github.com/alphagov/digitalmarketplace-frameworks/pull/588 for more specific information and screenshots of the changes. This quite simply pulls in the new frameworks & doesn't do anything else fancy.

Testing this locally, it doesn't _appear_ to break functional tests. But we won't know on preview until we bring preview's DOS4 live, which will probably be a way off.
