### PR TITLE
Replace hardcoded support email address with config setting

### DIFF
--- a/app/create_buyer/views/create_buyer.py
+++ b/app/create_buyer/views/create_buyer.py
@@ -31,6 +31,7 @@ def submit_create_buyer_account():
         if not data_api_client.is_email_address_with_valid_buyer_domain(email_address):
             return render_template(
                 "create_buyer/create_buyer_user_error.html",
+                support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS'],
                 error='invalid_buyer_domain'), 400
         else:
             send_user_account_email(

--- a/app/main/views/digital_outcomes_and_specialists.py
+++ b/app/main/views/digital_outcomes_and_specialists.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from app import data_api_client
+from flask import current_app
 
 from dmutils.flask import timed_render_template as render_template
 
@@ -18,6 +19,7 @@ def studios_start_page(framework_slug):
     return render_template(
         "buyers/studios_start_page.html",
         framework=framework,
+        support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS']
     ), 200
 
 

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -91,7 +91,7 @@ Find a user research lab - Digital Marketplace
         {% include "toolkit/documents.html" %}
         {% endwith %}
 
-        <p>Get help filtering the list at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a></p>
+        <p>Get help filtering the list at <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
 
     </div>
 </div>

--- a/app/templates/create_buyer/create_buyer_user_error.html
+++ b/app/templates/create_buyer/create_buyer_user_error.html
@@ -20,7 +20,7 @@
       <div class="explanation-list">
         <p class="lead">
           <a href="{{ url_for('.create_buyer_account') }}">Create an account using a different email address</a> or email
-          <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if:
+          <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> if:
         </p>
         <ul class="list-bullet">
           <li>
@@ -43,7 +43,7 @@
   <p>
     The link you used to create an account may have expired.<br/>
     Check you’ve entered the correct link or <a href="{{ url_for('.create_buyer_account') }}">send a new one</a>.<br/>
-    If you still can’t create an account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+    If you still can’t create an account, email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a>
   </p>
 
 {% elif user %}
@@ -54,7 +54,7 @@
       <h1>Your account has been deactivated.</h1>
     </header>
     <p>
-      Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to reactivate your account.
+      Email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to reactivate your account.
     </p>
 
   {% elif user.locked %}
@@ -63,7 +63,7 @@
       <h1>Your account has been locked.</h1>
     </header>
     <p>
-      Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to unlock your account.
+      Email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to unlock your account.
     </p>
 
   {% elif user.role == 'supplier' %}
@@ -73,7 +73,7 @@
     </header>
     <p>Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
     <p>You can <a href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
-      <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to have your account
+      <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to have your account
       converted to a buyer account.</p>
     <p>
       Alternatively, <a href="{{ url_for('external.render_login') }}">Log in</a> to your {{ user.supplier_name }} account.

--- a/config.py
+++ b/config.py
@@ -37,6 +37,7 @@ class Config(object):
     NOTIFY_TEMPLATES = {
         "create_user_account": "84f5d812-df9d-4ab8-804a-06f64f5abd30",
     }
+    SUPPORT_EMAIL_ADDRESS = "cloud_digital@crowncommercial.gov.uk"
 
     # This is just a placeholder
     ES_ENABLED = True


### PR DESCRIPTION
https://trello.com/c/3om47rfx/601-update-remaining-instances-of-enquiriesdigitalmarketplaceservicegovuk-to-the-new-support-address

Centralises the support email rather than hardcoding it in:

- create buyer user error template
- user research studios start page template