### PR TITLE
Pull in FE toolkit error pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,9 +818,9 @@ detect-libc@^1.0.2:
   version "16.1.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#83c5ccce9884ca354ffc4899aff96f0c3e93e07a"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.0":
-  version "33.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87b965996196069d3ae7aeb55cc6cb9e3bcb0127"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.1.0":
+  version "34.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#acb4f5e2b902df76d5517a37512980e8b911902a"
   dependencies:
     del "^4.1.0"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
https://trello.com/c/3om47rfx/601-update-remaining-instances-of-enquiriesdigitalmarketplaceservicegovuk-to-the-new-support-address

Most of the 404 error pages fall through to the Buyer FE, which is showing the new support email address. But duff URLs served by the other FE apps (e.g. `/buyers/i-have-typed-this-url-badly`) haven't yet had the FE toolkit bumped.

The breaking change is for the reverted attempt to fix the JS for the functional tests.