### PR TITLE
Update Docker base image from 5.0.0 to 6.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:5.0.0
+FROM digitalmarketplace/base-frontend:6.0.0


### PR DESCRIPTION
digitalmarketplace/base-frontend:6.0.0 uses npm instead of yarn

This should fix the brief-responses release pipeline.

Ticket: https://trello.com/c/RrpjQDJi/278-replace-yarn-with-npm