### PR TITLE
Bump digitalmarketplace-frontend-toolkit dependency to 34.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -900,8 +900,8 @@
       "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.1.1"
     },
     "digitalmarketplace-frontend-toolkit": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#6f560ae6366e5f14b88881fd622bb9afb7651423",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.2.0",
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87fd99dddd47ab620db6fb83637f8c8bd10540c4",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.3.0",
       "requires": {
         "del": "^4.1.0",
         "govuk-elements-sass": "3.0.3",
@@ -2712,7 +2712,6 @@
         "glob": "^4.0.6",
         "gulp-util": "^3.0.0",
         "handlebars": "^2.0.0",
-        "jasmine": "github:dflynn15/jasmine-npm#5f74e4336b247e67bbc509a8f82f3c4fa6b52964",
         "lodash": "^4.3.0",
         "through2": "^0.6.1"
       },
@@ -2735,7 +2734,7 @@
         },
         "jasmine": {
           "version": "github:dflynn15/jasmine-npm#5f74e4336b247e67bbc509a8f82f3c4fa6b52964",
-          "from": "github:dflynn15/jasmine-npm",
+          "from": "github:dflynn15/jasmine-npm#5f74e4336b247e67bbc509a8f82f3c4fa6b52964",
           "requires": {
             "exit": "^0.1.2",
             "glob": "^3.2.11",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "1.2.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.1.1",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.3.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",


### PR DESCRIPTION
https://trello.com/c/lxumtOjc

re-freeze dependencies