### PR TITLE
Pull in DOS4 question length changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -896,8 +896,8 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#853bca9578705000e0129e3dc0b84c5eb18a1aa3",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.1.1"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#f4227e4e06e601063489aa7afba38429fb890c88",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.3.0"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b0287c4eb54721b126fb56050705cde5bd940efc",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "1.2.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.1.1",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.3.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",


### PR DESCRIPTION
Closes out https://trello.com/c/YELMUI7V/316-buyer-questions-should-have-longer-word-limit and https://trello.com/c/PhPYo3Ha/318-update-technical-competence-criteria-content

- Adds additional help text to the `technicalCompetenceCriteria` questions: https://github.com/alphagov/digitalmarketplace-frameworks/pull/593
- Increases word length for three buyer questions on `digital-outcomes`: https://github.com/alphagov/digitalmarketplace-frameworks/pull/594