### PR TITLE
43-create-a-base-page-for-the-apps

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,0 +1,3 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+// Insert line for each component module import

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 
 {% block page_title %}{{ question.question }} – Digital Marketplace{% endblock %}

--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}{{ brief.title or brief.lotName }} – Digital Marketplace{% endblock %}
 

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% import "toolkit/forms/macros/forms.html" as forms %}
 

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% import "toolkit/forms/macros/forms.html" as forms %}
 

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% import "macros/brief_links.html" as brief_links %}
 

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Your account - Digital Marketplace{% endblock %}
 

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Responses to {{ brief.title or brief.lotName }} – Digital Marketplace{% endblock %}
 

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% import "toolkit/forms/macros/forms.html" as forms %}
 

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 {% block page_title %}Your requirements - Digital Marketplace
 {% endblock %}

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% block page_title %}Your account - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}{{ section.name }} – Digital Marketplace{% endblock %}
 

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% set title_text =
     {

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}
 Find a user research lab - Digital Marketplace

--- a/app/templates/buyers/supplier_questions.html
+++ b/app/templates/buyers/supplier_questions.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Supplier questions – Digital Marketplace{% endblock %}
 

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Create buyer account – Digital Marketplace{% endblock %}

--- a/app/templates/create_buyer/create_buyer_user_error.html
+++ b/app/templates/create_buyer/create_buyer_user_error.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Create account error – Digital Marketplace{% endblock %}
 

--- a/app/templates/create_buyer/create_your_account_complete.html
+++ b/app/templates/create_buyer/create_your_account_complete.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Activate your account - Digital Marketplace{% endblock %}


### PR DESCRIPTION
https://trello.com/c/PpFz5qRc/43-create-a-base-page-for-the-apps

The work to move to govuk-frontend will be easier if we have a base page in each app in which to import macros.

GOVUK Frontend may solve this down the road
https://github.com/alphagov/govuk-frontend/issues/1278

It seems from research (Googling and GOV Pay) for now this is the accepted pattern