### PR TITLE
switch most buttons to use digitalmarketplace-govuk-frontend

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -59,6 +59,9 @@ $govuk-compatibility-govukelements: true;
 @import "_secondary-action-link.scss";
 @import "_error-pages.scss";
 
+// Overrides
+@import "overrides/_notifications_banner";
+
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit
 #wrapper {

--- a/app/assets/scss/overrides/_notifications_banner.scss
+++ b/app/assets/scss/overrides/_notifications_banner.scss
@@ -1,0 +1,7 @@
+// Currently needed to force more margin between notification banner's
+// content and action buttons
+
+.app-banner-action {
+  @include govuk-responsive-margin(1, "top");
+  @include govuk-responsive-margin(0, "bottom");
+}

--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -44,14 +44,10 @@
                     {% endwith %}
 
                     {% block save_button %}
-                      {%
-                        with
-                        label="Save and continue",
-                        name="save_and_continue",
-                        type="save"
-                      %}
-                        {% include "toolkit/button.html" %}
-                      {% endwith %}
+                      {{ govukButton({
+                        "text": "Save and continue",
+                        "name": "save_and_continue",
+                      }) }}
                     {% endblock %}
               </form>
               {%

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -35,14 +35,10 @@
           {% endfor %}
 
           {% block save_button %}
-            {%
-              with
-              label="Update requirements",
-              name="submit",
-              type="save"
-            %}
-              {% include "toolkit/button.html" %}
-            {% endwith %}
+            {{ govukButton({
+              "text": "Update requirements",
+              "name": "submit",
+            }) }}
           {% endblock %}
       </form>
       {%

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -48,14 +48,10 @@
             {% endwith %}
 
             {% block save_button %}
-              {%
-                with
-                label="Save and continue",
-                name="submit",
-                type="save"
-              %}
-                {% include "toolkit/button.html" %}
-              {% endwith %}
+              {{ govukButton({
+                "text": "Save and continue",
+                "name": "submit",
+              }) }}
             {% endblock %}
           </form>
         {% endif %}

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -24,7 +24,10 @@
               with
               message = "Are you sure you want to delete these requirements?",
               type = "destructive",
-              action = '<button type="submit" class="button-destructive banner-action">Yes, delete</button>'|safe
+              action = govukButton({
+                "text": "Yes, delete",
+                "classes": "govuk-button--warning app-banner-action",
+              })
             %}
               {% include "toolkit/notification-banner.html" %}
             {% endwith %}
@@ -47,7 +50,10 @@
               heading = "Are you sure you want to withdraw these requirements?",
               banner_content = "<p>{}</p><ul><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
               type = "destructive",
-              action = '<button type="submit" class="button-destructive banner-action">Withdraw requirements</button>'|safe
+              action = govukButton({
+                "text": "Withdraw requirements",
+                "classes": "govuk-button--warning app-banner-action",
+              })
             %}
               {% include "toolkit/notification-banner.html" %}
             {% endwith %}

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -116,13 +116,9 @@
       {% if not published %}
         <form action="{{ url_for('.publish_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          {%
-          with
-          type = "save",
-          label = "Publish requirements"
-          %}
-          {% include "toolkit/button.html" %}
-          {% endwith %}
+          {{ govukButton({
+            "text": "Publish requirements",
+          }) }}
         </form>
       {% endif %}
     {% endif %}

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -46,15 +46,11 @@
           {% endwith %}
 
           {% block save_button %}
-            {%
-              with
-              label="Update requirements",
-              name="submit",
-              type="save"
-            %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
-        {% endblock %}
+            {{ govukButton({
+              "text": "Update requirements",
+              "name": "submit",
+            }) }}
+          {% endblock %}
         </form>
 
         {%

--- a/app/templates/buyers/create_brief_question.html
+++ b/app/templates/buyers/create_brief_question.html
@@ -29,13 +29,9 @@
 
 {% block save_button %}
 
-  {%
-    with
-    label="Save and continue",
-    type="save",
-    name = "return_to_overview"
-  %}
-    {% include "toolkit/button.html" %}
-  {% endwith %}
+  {{ govukButton({
+    "text": "Save and continue",
+    "name": "return_to_overview",
+  }) }}
 
 {% endblock %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -50,7 +50,15 @@
         {% else %}
             {{ summary.text() }}
         {% endif %}
-        {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {% call summary.field(action=True) %}
+          <form method="post" action="{{ url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
+            {{ govukButton({
+              "text": "Make a copy",
+              "classes": "govuk-button--secondary govuk-!-margin-0",
+            }) }}
+          </form>
+        {% endcall %}
     {% endcall %}
 {% endcall %}
 
@@ -72,7 +80,15 @@
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.publishedAt|dateformat) }}
         {{ summary.text(item.applicationsClosedAt|dateformat) }}
-        {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {% call summary.field(action=True) %}
+          <form method="post" action="{{ url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
+            {{ govukButton({
+              "text": "Make a copy",
+              "classes": "govuk-button--secondary govuk-!-margin-0",
+            }) }}
+          </form>
+        {% endcall %}
     {% endcall %}
 {% endcall %}
 
@@ -102,17 +118,36 @@
             </div>
             <form method="post" action="{{ url_for('.copy_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
-                <button type="submit" class="button-secondary">Make a copy</button>
+                {{ govukButton({
+                  "text": "Make a copy",
+                  "classes": "govuk-button--secondary govuk-!-margin-0",
+                }) }}
             </form>
           {% endcall %}
         {% elif item.status == "withdrawn" %}
           {{ summary.service_link(item.title, url_for("external.get_brief_by_id", framework_family=item.framework.family, brief_id=item.id)) }}
           {{ summary.text("Withdrawn") }}
-          {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+          {% call summary.field(action=True) %}
+            <form method="post" action="{{ url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
+              {{ govukButton({
+                "text": "Make a copy",
+                "classes": "govuk-button--secondary govuk-!-margin-0",
+              }) }}
+            </form>
+          {% endcall %}
         {% elif item.status in ["awarded", "cancelled", "unsuccessful"] %}
           {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
           {{ summary.text(item.applicationsClosedAt|dateformat) }}
-          {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+          {% call summary.field(action=True) %}
+            <form method="post" action="{{ url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
+              {{ govukButton({
+                "text": "Make a copy",
+                "classes": "govuk-button--secondary govuk-!-margin-0",
+              }) }}
+            </form>
+          {% endcall %}
         {% endif %}
      {% endcall %}
 {% endcall %}

--- a/app/templates/buyers/edit_brief_question.html
+++ b/app/templates/buyers/edit_brief_question.html
@@ -18,14 +18,10 @@
 
 {% block save_button %}
 
-  {%
-    with
-    label= button_label or "Save and continue",
-    type="save",
-    name = "return_to_overview"
-  %}
-    {% include "toolkit/button.html" %}
-  {% endwith %}
+  {{ govukButton({
+    "text": button_label or "Save and continue",
+    "name": "return_to_overview",
+  }) }}
 
   {%
     with

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -103,13 +103,9 @@
     <div class="column-two-thirds large-paragraph">
         <form action="{{ url_for('buyers.start_new_brief', framework_slug=framework.slug, lot_slug=lot.slug) }}" method="get">
 
-            {%
-                with
-                label="Create requirement",
-                type="save"
-            %}
-                {% include "toolkit/button.html" %}
-            {% endwith %}
+            {{ govukButton({
+              "text": "Create requirement",
+            }) }}
 
         </form>
     </div>

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -62,7 +62,10 @@ class TestAwardBrief(BaseApplicationTest):
         page_title = self._strip_whitespace(document.xpath('//h1')[0].text_content())
         assert page_title == "WhowontheIneedathingtodoathingcontract?"
 
-        submit_button = document.xpath('//input[@class="button-save" and @value="Save and continue"]')
+        submit_button = document.xpath(
+            '//button[normalize-space(string())=$t]',
+            t="Save and continue",
+        )
         assert len(submit_button) == 1
 
         # No options should be selected
@@ -248,7 +251,10 @@ class TestAwardBriefDetails(BaseApplicationTest):
         page_title = self._strip_whitespace(document.xpath('//h1')[0].text_content())
         assert page_title == "TellusaboutyourcontractwithBananaCorp"
 
-        submit_button = document.xpath('//input[@class="button-save" and @value="Update requirements"]')
+        submit_button = document.xpath(
+            '//button[@type="submit"][normalize-space(string())=$t]',
+            t="Update requirements",
+        )
         assert len(submit_button) == 1
 
         secondary_link_text = document.xpath('//div[@class="secondary-action-link"]//a[1]')[0]
@@ -423,7 +429,10 @@ class TestCancelBrief(BaseApplicationTest):
         page_title = document.xpath('//h1')[0].text_content()
         assert "Why do you need to cancel {}?".format(self.brief.get('title')) in page_title
 
-        submit_button = document.xpath('//input[@class="button-save" and @value="Update requirements"]')
+        submit_button = document.xpath(
+            '//button[normalize-space(string())=$t]',
+            t="Update requirements",
+        )
         assert len(submit_button) == 1
 
         expected_previous_page_link_text = 'Previous page'
@@ -465,7 +474,10 @@ class TestCancelBrief(BaseApplicationTest):
         page_title = document.xpath('//h1')[0].text_content()
         assert "Why didn’t you award a contract for {}?".format(self.brief.get('title')) in page_title
 
-        submit_button = document.xpath('//input[@class="button-save" and @value="Update requirements"]')
+        submit_button = document.xpath(
+            '//button[normalize-space(string())=$t]',
+            t="Update requirements",
+        )
         assert len(submit_button) == 1
 
         expected_previous_page_link_text = 'Previous page'


### PR DESCRIPTION
https://trello.com/c/4vOITu1f

~@lfdebrux it didn't turn out to be easy to switch the in-summary-table buttons without breaking out into raw html. The summary table macros really don't seem to have any capacity for arbitrary content.~ This is not true - it's just the ability to do so doesn't really have any examples in the documentation - I'll have another go...

Pages all (FSVO "all" - I could have missed some cases in my checking) seem to work and look approximately right.