### PR TITLE
replaces classes for list, anchor and paragraph elements excluding instruction-list

### DIFF
--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -25,10 +25,10 @@
               {% endwith %}
 
               <form method="POST" action="{{ url_for('.award_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
-                  <p class="question-advice">
+                  <p class="govuk-body">
                       This information will be added to your requirements. Suppliers will receive a link to view the update.
                   </p>
-                  <p class="question-advice">
+                  <p class="govuk-body">
                       You’ll still need to contact suppliers to give them feedback.
                   </p>
 

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -25,7 +25,7 @@
             {% include 'toolkit/page-heading.html' %}
           {% endwith %}
             <p>
-              <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">View the outcome of the requirements</a>
+              <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">View the outcome of the requirements</a>
             </p>
       {% else %}
         {% with

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -24,7 +24,7 @@
           %}
             {% include 'toolkit/page-heading.html' %}
           {% endwith %}
-            <p>
+            <p class="govuk-body">
               <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">View the outcome of the requirements</a>
             </p>
       {% else %}

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -50,7 +50,7 @@
             {%
               with
               heading = "Are you sure you want to withdraw these requirements?",
-              banner_content = "<p>{}</p><ul class='govuk-list govuk-list--bullet'><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
+              banner_content = "<p class='govuk-body'>{}</p><ul class='govuk-list govuk-list--bullet'><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
               type = "destructive",
               action = govukButton({
                 "text": "Withdraw requirements",

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -257,7 +257,7 @@
                           <img src="{{ asset_path }}svg/tick.svg" alt="done" width="15" height="14" />
                         </span>
                       {% endif %}
-                      <a href="{{ brief_links.brief_link_url('grandparent', section, brief) }}">{{ section.name }}</a>
+                      <a class="govuk-link" href="{{ brief_links.brief_link_url('grandparent', section, brief) }}">{{ section.name }}</a>
                     </li>
                     {% endif %}
                   {% endfor %}
@@ -268,7 +268,7 @@
                 {% for link in step.links %}
                   {% if not link.allowed_statuses or brief.status in link.allowed_statuses %}
                     <li>
-                      <a href="{{ link.href }}">{{ link.text }}</a>
+                      <a class="govuk-link" href="{{ link.href }}">{{ link.text }}</a>
                     </li>
                   {% endif %}
                 {% endfor %}
@@ -281,14 +281,14 @@
     </div>
     <div class="column-one-third">
       {% if brief.status == 'closed' %}
-        <a href="{{ url_for('buyers.cancel_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel requirements</a>
+        <a class="govuk-link" href="{{ url_for('buyers.cancel_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel requirements</a>
       {% elif brief.status == 'live' %}
         {% if not withdraw_requested %}
-          <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, withdraw_requested=True) }}">Withdraw requirements</a>
+          <a class="govuk-link" href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, withdraw_requested=True) }}">Withdraw requirements</a>
         {% endif %}
       {% elif brief.status == 'draft' %}
         {% if not delete_requested %}
-          <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, delete_requested=True) }}">Delete draft requirements</a>
+          <a class="govuk-link" href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, delete_requested=True) }}">Delete draft requirements</a>
         {% endif %}
       {% endif %}
     </div>

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -50,7 +50,7 @@
             {%
               with
               heading = "Are you sure you want to withdraw these requirements?",
-              banner_content = "<p>{}</p><ul><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
+              banner_content = "<p>{}</p><ul class='govuk-list govuk-list--bullet'><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
               type = "destructive",
               action = govukButton({
                 "text": "Withdraw requirements",

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -29,7 +29,7 @@
         <p>All requirements are published on the Digital Marketplace where anyone can see them.</p>
       </div>
         {% if brief.lotSlug == 'digital-specialists' and not brief.requirementsLength %}
-          <p><a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
+          <p><a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
           <div class="dmspeak">
             <p>This will show you what the supplier application deadline will be if you publish your requirements today.</p>
           </div>
@@ -58,7 +58,7 @@
           {% if question.answer_required and not question.id == 'requirementsLength' %}
             <ol class="govuk-list govuk-list--number">
               <li>
-                <a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
+                <a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
               </li>
             </ol>
           {% endif %}

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -56,7 +56,7 @@
       {% for section in sections %}
         {% for question in section.questions %}
           {% if question.answer_required and not question.id == 'requirementsLength' %}
-            <ol>
+            <ol class="govuk-list govuk-list--number">
               <li>
                 <a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
               </li>

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -26,32 +26,32 @@
 
     {% if not published %}
       <div class="dmspeak">
-        <p>All requirements are published on the Digital Marketplace where anyone can see them.</p>
+        <p class="govuk-body">All requirements are published on the Digital Marketplace where anyone can see them.</p>
       </div>
         {% if brief.lotSlug == 'digital-specialists' and not brief.requirementsLength %}
-          <p><a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
+          <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
           <div class="dmspeak">
-            <p>This will show you what the supplier application deadline will be if you publish your requirements today.</p>
+            <p class="govuk-body">This will show you what the supplier application deadline will be if you publish your requirements today.</p>
           </div>
         {% else %}
-          <p>Your requirements will be open for {{ dates.application_open_weeks }}.</p>
+          <p class="govuk-body">Your requirements will be open for {{ dates.application_open_weeks }}.</p>
           <div class="dmspeak">
-            <p>If you publish your requirements today ({{ dates.published_date | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_date | utcdatetimeformat }}.</p>
+            <p class="govuk-body">If you publish your requirements today ({{ dates.published_date | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_date | utcdatetimeformat }}.</p>
           </div>
         {% endif %}
     {% endif %}
 
-    <p>Supplier questions will be sent to:</p>
+    <p class="govuk-body">Supplier questions will be sent to:</p>
     <div class="dmspeak">
-      <p>{{ email_address }}</p>
+      <p class="govuk-body">{{ email_address }}</p>
     </div>
     <div class="dmspeak">
-      <p>Make sure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
+      <p class="govuk-body">Make sure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
     </div>
 
     {% if not published and unanswered_required > 0 %}
       <div class="dmspeak">
-        <p><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
+        <p class="govuk-body"><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
       </div>
       {% for section in sections %}
         {% for question in section.questions %}

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -49,7 +49,7 @@
           </div>
           {% with items = [
               {
-                  "body": 'Read the <a href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">guidance on how to shortlist.</a>'|safe,
+                  "body": 'Read the <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">guidance on how to shortlist.</a>'|safe,
               },
               {
                   "body": 'Review and score the evidence suppliers have given.',
@@ -87,7 +87,7 @@
                 Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
             </p>
             <p>
-              Download the list of supplier responses and follow the guidance on <a href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">how to shortlist</a>.
+              Download the list of supplier responses and follow the guidance on <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">how to shortlist</a>.
             </p>
           </div>
 

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -121,7 +121,7 @@
             <p class='lead'>
                 If you still need this service, you should start the buying process again. Consider:
             </p>
-            <ul class='list-bullet'>
+            <ul class='govuk-list govuk-list--bullet'>
                 <li>talking to suppliers before you start</li>
                 <li>rewriting your requirements</li>
             </ul>

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -38,12 +38,12 @@
       {% if response_counts['eligible'] > 0 %}
         {% if brief_responses_required_evidence %}
           <div class="dmspeak">
-              <p>
+              <p class="govuk-body">
                 <span class='visual-emphasis'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
                 responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience.
                 Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
               </p>
-              <p>
+              <p class="govuk-body">
                 You said you’d take <span class='visual-emphasis'>{{ brief.numberOfSuppliers }} {{ pluralize(brief.numberOfSuppliers, "supplier", "suppliers") }}</span> through to the evaluation stage. To do this, you need to:
               </p>
           </div>
@@ -81,12 +81,12 @@
 
         {% else %}
           <div class="dmspeak">
-            <p>
+            <p class="govuk-body">
                 <span class='visual-emphasis'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
                 responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience.
                 Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
             </p>
-            <p>
+            <p class="govuk-body">
               Download the list of supplier responses and follow the guidance on <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">how to shortlist</a>.
             </p>
           </div>
@@ -108,17 +108,17 @@
         {% endif %}
       {% else %}
         <div class="dmspeak">
-          <p>
+          <p class="govuk-body">
               No suppliers met your essential skills and experience requirements.
           </p>
           {% if (response_counts['eligible'] or response_counts['failed']) and not brief_responses_required_evidence %}
-            <p>
+            <p class="govuk-body">
                 All the suppliers who applied have already been told they were unsuccessful.
             </p>
           {% endif %}
         </div>
         <div class='explanation-list'>
-            <p class='lead'>
+            <p class="govuk-body-l">
                 If you still need this service, you should start the buying process again. Consider:
             </p>
             <ul class='govuk-list govuk-list--bullet'>

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -29,10 +29,10 @@
 
         <form method="POST" action="{{ url_for(request.endpoint, framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          <p class="question-advice">
+          <p class="govuk-body">
               This information will be added to your requirements. Suppliers will receive a link to view the update.
           </p>
-          <p class="question-advice">
+          <p class="govuk-body">
               You’ll still need to contact suppliers to give them feedback.
           </p>
           {%

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -113,9 +113,9 @@
           {{ summary.text(item.applicationsClosedAt|dateformat) }}
           {% call summary.field(action=True) %}
             <div class="padding-bottom-small">
-                <p><a href="{{ url_for('.view_brief_responses', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">View responses</a></p>
+                <p><a class="govuk-link" href="{{ url_for('.view_brief_responses', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">View responses</a></p>
                 {% if item.status == "closed" %}
-                    <p><a class="award-contract-link" href="{{ url_for('.award_or_cancel_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
+                    <p><a class="govuk-link" class="award-contract-link" href="{{ url_for('.award_or_cancel_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
                 {% endif %}
             </div>
             <form method="post" action="{{ url_for('.copy_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -115,7 +115,7 @@
             <div class="padding-bottom-small">
                 <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.view_brief_responses', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">View responses</a></p>
                 {% if item.status == "closed" %}
-                    <p class="govuk-body"><a class="govuk-link" class="award-contract-link" href="{{ url_for('.award_or_cancel_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
+                    <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.award_or_cancel_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
                 {% endif %}
             </div>
             <form method="post" action="{{ url_for('.copy_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -113,9 +113,9 @@
           {{ summary.text(item.applicationsClosedAt|dateformat) }}
           {% call summary.field(action=True) %}
             <div class="padding-bottom-small">
-                <p><a class="govuk-link" href="{{ url_for('.view_brief_responses', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">View responses</a></p>
+                <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.view_brief_responses', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">View responses</a></p>
                 {% if item.status == "closed" %}
-                    <p><a class="govuk-link" class="award-contract-link" href="{{ url_for('.award_or_cancel_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
+                    <p class="govuk-body"><a class="govuk-link" class="award-contract-link" href="{{ url_for('.award_or_cancel_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">Let suppliers know the outcome</a></p>
                 {% endif %}
             </div>
             <form method="post" action="{{ url_for('.copy_brief', framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id) }}">

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -39,7 +39,7 @@
             You need to tell us the outcome for {{ user_projects_awaiting_outcomes_total }}
             {{ pluralize(user_projects_awaiting_outcomes_total, "saved search", "saved searches") }}.<br>
           {% endif %}
-          <a href="/buyers/direct-award/g-cloud">View your saved searches</a><br>
+          <a class="govuk-link" href="/buyers/direct-award/g-cloud">View your saved searches</a><br>
         {% else %}
           You don't have any saved searches.
         {% endif %}
@@ -48,7 +48,7 @@
       <h2 class="heading-xmedium">Digital outcomes, specialists and user research participants</h2>
       <p>
         {% if user_briefs_total %}
-          <a href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>  
+          <a class="govuk-link" href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>  
         {% else %}   
           You don't have any requirements.
         {% endif %}
@@ -60,11 +60,12 @@
     <h2 class="heading-xmedium">Account settings</h2>
 
     <p>
-      <a href="{{ url_for('external.change_password') }}">Change your password</a>
+      <a class="govuk-link" href="{{ url_for('external.change_password') }}">Change your password</a>
     </p>
 
     <p>
       <a
+        class="govuk-link"
         href="{{ url_for('external.user_research_consent') }}"
         data-analytics="trackEvent"
         data-analytics-category="user-research"

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -33,7 +33,7 @@
 
     <div class="dmspeak">
       <h2 class="heading-xmedium">Cloud hosting, software and support</h2>
-      <p>
+      <p class="govuk-body">
         {% if user_has_projects %}
           {% if user_projects_awaiting_outcomes_total %}
             You need to tell us the outcome for {{ user_projects_awaiting_outcomes_total }}
@@ -46,7 +46,7 @@
       </p>
     
       <h2 class="heading-xmedium">Digital outcomes, specialists and user research participants</h2>
-      <p>
+      <p class="govuk-body">
         {% if user_briefs_total %}
           <a class="govuk-link" href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>  
         {% else %}   
@@ -59,11 +59,11 @@
   <div class="column-one-third dmspeak">
     <h2 class="heading-xmedium">Account settings</h2>
 
-    <p>
+    <p class="govuk-body">
       <a class="govuk-link" href="{{ url_for('external.change_password') }}">Change your password</a>
     </p>
 
-    <p>
+    <p class="govuk-body">
       <a
         class="govuk-link"
         href="{{ url_for('external.user_research_consent') }}"

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -54,7 +54,7 @@
           {% if question.answer_required or question.is_empty %}
             {% if brief.get('status') == 'draft' %}
               {% call summary.field() %}
-                <a href="{{ url_for('buyers.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
+                <a class="govuk-link" href="{{ url_for('buyers.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
               {% endcall %}
             {% else %}
               {{ summary.text("Not answered") }}

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -40,18 +40,18 @@
     <div class="column-two-thirds large-paragraph">
         <div class="marketplace-paragraph">
                  {% set digital_specialists_intro %}
-                    <p>You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.</p>
-                    <p>You need to write ‘requirements’ to describe the work and tell suppliers to provide a specialist. The specialist can’t work for you outside the scope of your written requirements.</p>
+                    <p class="govuk-body">You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.</p>
+                    <p class="govuk-body">You need to write ‘requirements’ to describe the work and tell suppliers to provide a specialist. The specialist can’t work for you outside the scope of your written requirements.</p>
                 {% endset %}
 
                  {% set digital_outcomes_intro %}
-                    <p>You can use the Digital Marketplace to find a team to work on a digital outcome, such as a booking system or an accessibility audit.</p>
-                    <p>You need to write ‘requirements’ to describe the situation or problem and ask suppliers to propose a solution and provide a team.</p>
-                    <p>The members of the team can’t work for you outside the scope of your written requirements.</p>
+                    <p class="govuk-body">You can use the Digital Marketplace to find a team to work on a digital outcome, such as a booking system or an accessibility audit.</p>
+                    <p class="govuk-body">You need to write ‘requirements’ to describe the situation or problem and ask suppliers to propose a solution and provide a team.</p>
+                    <p class="govuk-body">The members of the team can’t work for you outside the scope of your written requirements.</p>
                 {% endset %}
 
                 {% set user_research_participants_intro %}
-                    <p>To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.</p>
+                    <p class="govuk-body">To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.</p>
                 {% endset %}
 
                 {{
@@ -90,8 +90,8 @@
             <li>Award a contract to the {{ "specialist" if lot.slug == "digital-specialists" else "supplier" }} that best meets your needs.</li>
         </ol>
 
-        <p>The buying process should take around 4 weeks.</p>
-        <p>Read more about:</p>
+        <p class="govuk-body">The buying process should take around 4 weeks.</p>
+        <p class="govuk-body">Read more about:</p>
         <div class="explanation-list">
             <ul class="govuk-list govuk-list--bullet">
                 <li><a class="govuk-link" href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">how to buy</a></li>

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -66,7 +66,7 @@
         <h2>Before you start</h2>
         <ol class="govuk-list govuk-list--number">
             <li>You can talk to suppliers to prepare your requirements.<br>
-                <a href="https://assets.digitalmarketplace.service.gov.uk/{{ framework.slug }}/communications/catalogues/{{ lot.slug }}-suppliers.csv">
+                <a class="govuk-link" href="https://assets.digitalmarketplace.service.gov.uk/{{ framework.slug }}/communications/catalogues/{{ lot.slug }}-suppliers.csv">
                     Download list of suppliers.
                 </a>
             </li>
@@ -94,8 +94,8 @@
         <p>Read more about:</p>
         <div class="explanation-list">
             <ul class="govuk-list govuk-list--bullet">
-                <li><a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">how to buy</a></li>
-                <li><a href="https://www.gov.uk/guidance/how-digital-marketplace-suppliers-have-been-evaluated">how suppliers have been evaluated</a></li>
+                <li><a class="govuk-link" href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">how to buy</a></li>
+                <li><a class="govuk-link" href="https://www.gov.uk/guidance/how-digital-marketplace-suppliers-have-been-evaluated">how suppliers have been evaluated</a></li>
             </ul>
         </div>
     </div>

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -64,7 +64,7 @@
         </div>
 
         <h2>Before you start</h2>
-        <ol class="list-number">
+        <ol class="govuk-list govuk-list--number">
             <li>You can talk to suppliers to prepare your requirements.<br>
                 <a href="https://assets.digitalmarketplace.service.gov.uk/{{ framework.slug }}/communications/catalogues/{{ lot.slug }}-suppliers.csv">
                     Download list of suppliers.
@@ -74,18 +74,18 @@
         </ol>
 
         <h2>Write and publish your requirements</h2>
-        <ol class="list-number" start="3">
+        <ol class="govuk-list govuk-list--number" start="3">
             <li>Write your requirements and say how you’re going to evaluate {{ "specialists" if lot.slug == "digital-specialists" else "suppliers" }}.</li>
             <li>Publish your requirements and evaluation criteria so suppliers can apply for the work. This information will be published on the Digital Marketplace where anyone can see it.</li>
         </ol>
 
         <h2>Answer supplier questions</h2>
-        <ol class="list-number" start="5">
+        <ol class="govuk-list govuk-list--number" start="5">
             <li>Post all supplier questions and answers on the Digital Marketplace.</li>
         </ol>
 
         <h2>Evaluate suppliers</h2>
-        <ol class="list-number" start="6">
+        <ol class="govuk-list govuk-list--number" start="6">
             <li>Shortlist and evaluate {{ "specialists’" if lot.slug == "digital-specialists" else "supplier" }} applications.</li>
             <li>Award a contract to the {{ "specialist" if lot.slug == "digital-specialists" else "supplier" }} that best meets your needs.</li>
         </ol>
@@ -93,7 +93,7 @@
         <p>The buying process should take around 4 weeks.</p>
         <p>Read more about:</p>
         <div class="explanation-list">
-            <ul class="list-bullet">
+            <ul class="govuk-list govuk-list--bullet">
                 <li><a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">how to buy</a></li>
                 <li><a href="https://www.gov.uk/guidance/how-digital-marketplace-suppliers-have-been-evaluated">how suppliers have been evaluated</a></li>
             </ul>

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -73,7 +73,7 @@
         </ol>
 
         <div class="marketplace-paragraph">
-            <p>Read more about <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
+            <p>Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
         </div>
 
         <h2>Download the list of labs</h2>
@@ -91,7 +91,7 @@
         {% include "toolkit/documents.html" %}
         {% endwith %}
 
-        <p>Get help filtering the list at <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
+        <p>Get help filtering the list at <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
 
     </div>
 </div>

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -37,7 +37,7 @@
         </div>
 
         <h2>Before you start</h2>
-        <ol class="list-number">
+        <ol class="govuk-list govuk-list--number">
             <li>
                 Prepare your requirements and set evaluation criteria.<br />
                 eg a lab in York with a desktop PC and an observation room
@@ -46,23 +46,23 @@
         </ol>
 
         <h2>Create a shortlist</h2>
-        <ol class="list-number" start="3">
+        <ol class="govuk-list govuk-list--number" start="3">
             <li>Download the list of user research labs from the Digital Marketplace.</li>
             <li>Filter the list of labs on location and your requirements to create a shortlist.</li>
         </ol>
 
         <h2>Contact your shortlist</h2>
-        <ol class="list-number" start="5">
+        <ol class="govuk-list govuk-list--number" start="5">
             <li>Send your requirements and evaluation criteria to shortlisted suppliers.</li>
             <li>Answer supplier questions.</li>
             <li>Suppliers will tell you if they can meet your requirements.</li>
         </ol>
 
         <h2>Evaluate</h2>
-        <ol class="list-number" start="8">
+        <ol class="govuk-list govuk-list--number" start="8">
             <li>Evaluate suppliers responses on:
                 <div class="explanation-list">
-                    <ul class="list-bullet">
+                    <ul class="govuk-list govuk-list--bullet">
                         <li>availability</li>
                         <li>location, facilities and accessibility</li>
                         <li>price</li>

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -31,7 +31,7 @@
 
     <div class="column-two-thirds large-paragraph">
         <div class="marketplace-paragraph">
-            <p>
+            <p class="govuk-body">
                 To find a user research lab, you need to tell suppliers what facilities you need and when. They’ll then tell you what they can do and how much it will cost.
             </p>
         </div>
@@ -73,7 +73,7 @@
         </ol>
 
         <div class="marketplace-paragraph">
-            <p>Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
+            <p class="govuk-body">Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
         </div>
 
         <h2>Download the list of labs</h2>
@@ -91,7 +91,7 @@
         {% include "toolkit/documents.html" %}
         {% endwith %}
 
-        <p>Get help filtering the list at <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
+        <p class="govuk-body">Get help filtering the list at <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
 
     </div>
 </div>

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -42,7 +42,7 @@
     <form method="POST" action="{{ url_for('.submit_create_buyer_account') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       {{ form.email_address }}
-      <p>We will send an account activation email to this address. You will then be able to set your password.</p>
+      <p class="govuk-body">We will send an account activation email to this address. You will then be able to set your password.</p>
       {%
         with
           type = "save",

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -32,7 +32,7 @@
 {% include "toolkit/page-heading.html" %}
 {% endwith %}
 
-<p class="lede">
+<p class="govuk-body-l">
   You must be employed by, or represent, a public sector organisation.
 </p>
 

--- a/app/templates/create_buyer/create_buyer_user_error.html
+++ b/app/templates/create_buyer/create_buyer_user_error.html
@@ -21,8 +21,8 @@
       </p>
       <div class="explanation-list">
         <p class="lead">
-          <a href="{{ url_for('.create_buyer_account') }}">Create an account using a different email address</a> or email
-          <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> if:
+          class="govuk-link" href="{{ url_for('.create_buyer_account') }}">Create an account using a different email address</a> or email
+          <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> if:
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li>
@@ -44,8 +44,8 @@
   </header>
   <p>
     The link you used to create an account may have expired.<br/>
-    Check you’ve entered the correct link or <a href="{{ url_for('.create_buyer_account') }}">send a new one</a>.<br/>
-    If you still can’t create an account, email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a>
+    Check you’ve entered the correct link or <a class="govuk-link" href="{{ url_for('.create_buyer_account') }}">send a new one</a>.<br/>
+    If you still can’t create an account, email <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a>
   </p>
 
 {% elif user %}
@@ -56,7 +56,7 @@
       <h1>Your account has been deactivated.</h1>
     </header>
     <p>
-      Email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to reactivate your account.
+      Email <a class="govuk-link" class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to reactivate your account.
     </p>
 
   {% elif user.locked %}
@@ -65,7 +65,7 @@
       <h1>Your account has been locked.</h1>
     </header>
     <p>
-      Email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to unlock your account.
+      Email <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to unlock your account.
     </p>
 
   {% elif user.role == 'supplier' %}
@@ -74,11 +74,11 @@
       <h1>The details you provided are registered with a supplier.</h1>
     </header>
     <p>Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
-    <p>You can <a href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
-      <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to have your account
+    <p>You can <a class="govuk-link" href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
+      <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to have your account
       converted to a buyer account.</p>
     <p>
-      Alternatively, <a href="{{ url_for('external.render_login') }}">Log in</a> to your {{ user.supplier_name }} account.
+      Alternatively, <a class="govuk-link" href="{{ url_for('external.render_login') }}">Log in</a> to your {{ user.supplier_name }} account.
     </p>
 
   {% else %}
@@ -88,7 +88,7 @@
     </header>
 
     <p>
-      <a href="{{ url_for('external.render_login') }}">Log in</a> to your account.
+      <a class="govuk-link" href="{{ url_for('external.render_login') }}">Log in</a> to your account.
     </p>
 
   {% endif %}

--- a/app/templates/create_buyer/create_buyer_user_error.html
+++ b/app/templates/create_buyer/create_buyer_user_error.html
@@ -56,7 +56,7 @@
       <h1>Your account has been deactivated.</h1>
     </header>
     <p class="govuk-body">
-      Email <a class="govuk-link" class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to reactivate your account.
+      Email <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to reactivate your account.
     </p>
 
   {% elif user.locked %}

--- a/app/templates/create_buyer/create_buyer_user_error.html
+++ b/app/templates/create_buyer/create_buyer_user_error.html
@@ -24,7 +24,7 @@
           <a href="{{ url_for('.create_buyer_account') }}">Create an account using a different email address</a> or email
           <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> if:
         </p>
-        <ul class="list-bullet">
+        <ul class="govuk-list govuk-list--bullet">
           <li>
             you think your domain should be recognised
           </li>

--- a/app/templates/create_buyer/create_buyer_user_error.html
+++ b/app/templates/create_buyer/create_buyer_user_error.html
@@ -13,14 +13,14 @@
       <header class="page-heading-smaller">
         <h1>You must use a public sector email address</h1>
       </header>
-      <p>
+      <p class="govuk-body">
         You must be employed by, or represent, a public sector organisation to create a buyer account.
       </p>
-      <p>
+      <p class="govuk-body">
         The email you used doesn't belong to a recognised public sector domain.
       </p>
       <div class="explanation-list">
-        <p class="lead">
+        <p class="govuk-body-l">
           class="govuk-link" href="{{ url_for('.create_buyer_account') }}">Create an account using a different email address</a> or email
           <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> if:
         </p>
@@ -42,7 +42,7 @@
   <header class="page-heading-smaller">
     <h1>Expired link</h1>
   </header>
-  <p>
+  <p class="govuk-body">
     The link you used to create an account may have expired.<br/>
     Check you’ve entered the correct link or <a class="govuk-link" href="{{ url_for('.create_buyer_account') }}">send a new one</a>.<br/>
     If you still can’t create an account, email <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a>
@@ -55,7 +55,7 @@
     <header class="page-heading-smaller">
       <h1>Your account has been deactivated.</h1>
     </header>
-    <p>
+    <p class="govuk-body">
       Email <a class="govuk-link" class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to reactivate your account.
     </p>
 
@@ -64,7 +64,7 @@
     <header class="page-heading-smaller">
       <h1>Your account has been locked.</h1>
     </header>
-    <p>
+    <p class="govuk-body">
       Email <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to unlock your account.
     </p>
 
@@ -73,11 +73,11 @@
     <header class="page-heading-smaller">
       <h1>The details you provided are registered with a supplier.</h1>
     </header>
-    <p>Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
-    <p>You can <a class="govuk-link" href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
+    <p class="govuk-body">Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
+    <p class="govuk-body">You can <a class="govuk-link" href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
       <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to have your account
       converted to a buyer account.</p>
-    <p>
+    <p class="govuk-body">
       Alternatively, <a class="govuk-link" href="{{ url_for('external.render_login') }}">Log in</a> to your {{ user.supplier_name }} account.
     </p>
 
@@ -87,7 +87,7 @@
       <h1>Account already exists</h1>
     </header>
 
-    <p>
+    <p class="govuk-body">
       <a class="govuk-link" href="{{ url_for('external.render_login') }}">Log in</a> to your account.
     </p>
 

--- a/app/templates/create_buyer/create_your_account_complete.html
+++ b/app/templates/create_buyer/create_your_account_complete.html
@@ -30,7 +30,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      <p>
+      <p class="govuk-body">
         An email has been sent to {{ email_address }}.
         You need to click on the link in the email to activate your account.
       </p>


### PR DESCRIPTION
trello: https://trello.com/c/pNq68dXy/78-2-use-govuk-link-govuk-list-and-govuk-body-styles-in-briefs-frontend