### PR TITLE
Allow overriding the development server port using an environment variable

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,4 @@
+FLASK_APP=application:application
+FLASK_ENV=development
+FLASK_RUN_EXTRA_FILES=app/content/frameworks/
+FLASK_RUN_PORT=5005

--- a/.flaskenv
+++ b/.flaskenv
@@ -1,4 +1,7 @@
+DM_API_PORT=5000
+DM_BRIEFS_PORT=5005
+
 FLASK_APP=application:application
 FLASK_ENV=development
 FLASK_RUN_EXTRA_FILES=app/content/frameworks/
-FLASK_RUN_PORT=5005
+FLASK_RUN_PORT=${DM_BRIEFS_PORT}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ run-all: requirements npm-install frontend-build run-app
 
 .PHONY: run-app
 run-app: show-environment virtualenv
-	${VIRTUALENV_ROOT}/bin/python application.py runserver
+	${VIRTUALENV_ROOT}/bin/flask run
 
 .PHONY: virtualenv
 virtualenv:

--- a/README.md
+++ b/README.md
@@ -70,12 +70,18 @@ not already been set:
 make run-app
 ```
 
-More generally, the command to start the server is:
+More generally, the command to start the development server is:
 ```
-python application.py runserver
+DM_ENVIRONMENT=development flask run
 ```
 
-The app runs on port 5005 by default. Use the app at [http://127.0.0.1:5005/](http://127.0.0.1:5005/)
+When using the development server the app runs on port 5005 by default.
+This is configured in the `.flaskenv file; see the [Flask cli documentation]
+for details on how to configure the development server.
+
+Use the app at [http://127.0.0.1:5005/](http://127.0.0.1:5005/)
+
+[Flask cli documentation]: https://flask.palletsprojects.com/en/1.0.x/cli/
 
 ### Updating application dependencies
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,14 @@ More generally, the command to start the development server is:
 DM_ENVIRONMENT=development flask run
 ```
 
-When using the development server the app runs on port 5005 by default.
-This is configured in the `.flaskenv file; see the [Flask cli documentation]
-for details on how to configure the development server.
-
 Use the app at [http://127.0.0.1:5005/](http://127.0.0.1:5005/)
 
-[Flask cli documentation]: https://flask.palletsprojects.com/en/1.0.x/cli/
+When using the development server the app runs on port 5005 by default.
+This can be changed by setting the `DM_BRIEFS_PORT` environment variable, e.g.
+to set the port number to 9005:
+```
+export DM_BRIEFS_PORT=9005
+```
 
 ### Updating application dependencies
 

--- a/config.py
+++ b/config.py
@@ -94,7 +94,7 @@ class Development(Config):
     DM_PLAIN_TEXT_LOGS = True
     SESSION_COOKIE_SECURE = False
 
-    DM_DATA_API_URL = "http://localhost:5000"
+    DM_DATA_API_URL = f"http://localhost:{os.getenv('DM_API_PORT', 5000)}"
     DM_DATA_API_AUTH_TOKEN = "myToken"
 
     DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ lxml==4.3.4
 mock==3.0.5
 pytest==4.6.3
 pytest-cov==2.7.1
+python-dotenv==0.10.3  # used to load .flaskenv
 watchdog==0.9.0
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.1.2#egg=digitalmarketplace-test-utils==2.1.2


### PR DESCRIPTION
ticket: https://trello.com/c/cwjzIU8U/1212-stop-search-api-from-using-port-5001