### PR TITLE
Replacing toolkit/page-headings with govuk frontend heading

### DIFF
--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -13,14 +13,9 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-
-      {% with
-        heading = question.question,
-        smaller = true
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
-
+      <h1 class="govuk-heading-l">
+        {{ question.question }}
+      </h1>
     </div>
   </div>
 

--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -17,12 +17,7 @@
 <div class="grid-row">
     <div class="column-two-thirds">
           <div class="single-question-page">
-              {% with
-                    heading = "Who won the {} contract?".format(brief.title),
-                    smaller = true
-              %}
-                {% include 'toolkit/page-heading.html' %}
-              {% endwith %}
+              <h1 class="govuk-heading-l">Who won the {{ brief.title }} contract?</h1>
 
               <form method="POST" action="{{ url_for('.award_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
                   <p class="govuk-body">

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -18,13 +18,7 @@
   {% include 'toolkit/forms/validation.html' %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-        heading = "Tell us about your contract with {}".format(pending_brief_response.supplierName),
-        smaller = True
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
-
+      <h1 class="govuk-heading-l">Tell us about your contract with {{ pending_brief_response.supplierName }}</h1>
       <form method="POST" action="{{ url_for('.award_brief_details', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, brief_response_id=pending_brief_response.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {% for question in section.questions %}

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -18,23 +18,12 @@
     <div class="column-two-thirds">
       <div class="single-question-page">
         {% if already_awarded %}
-          {% with
-                heading = "Requirements already updated for {}".format(brief.title),
-                smaller = true
-          %}
-            {% include 'toolkit/page-heading.html' %}
-          {% endwith %}
-            <p class="govuk-body">
-              <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">View the outcome of the requirements</a>
-            </p>
+          <h1 class="govuk-heading-l">Requirements already updated for {{ brief.title }}</h1>
+          <p class="govuk-body">
+            <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">View the outcome of the requirements</a>
+          </p>
       {% else %}
-        {% with
-          heading = form.award_or_cancel_decision.label.text,
-          smaller = True
-        %}
-          {% include 'toolkit/page-heading.html' %}
-        {% endwith %}
-
+          <h1 class="govuk-heading-l">{{ form.award_or_cancel_decision.label.text }}</h1>
           <form method="POST" action="{{ url_for('.award_or_cancel_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             {%

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -67,9 +67,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = brief.get('title', brief['lotName']) %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-xl">{{ brief.get('title', brief['lotName']) }}</h1>
     </div>
   </div>
   <div class="grid-row">

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -16,14 +16,8 @@
 
 <div class='grid-row'>
   <div class='column-two-thirds large-paragraph'>
-    {% with
-        heading = "Publish your requirements and evaluation criteria" if not published else "Question and answer dates",
-        smaller = True,
-        with_breadcrumb = True
-    %}
-        {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-
+    {% set heading = "Publish your requirements and evaluation criteria" if not published else "Question and answer dates" %}
+    <h1 class="govuk-heading-l">{{ heading }}</h1>
     {% if not published %}
       <div class="dmspeak">
         <p class="govuk-body">All requirements are published on the Digital Marketplace where anyone can see them.</p>

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -16,20 +16,11 @@
 <div class="grid-row">
     <div class="column-two-thirds">
         {% if response_counts['eligible'] > 0 %}
-            {% with
-            heading = "Shortlist suppliers",
-            smaller = true
-            %}
-            {% include "toolkit/page-heading.html" %}
-            {% endwith %}
+          {% set heading = 'Shortlist suppliers' %}
         {% else %}
-            {% with
-            heading = "There were no applications",
-            smaller = true
-            %}
-            {% include "toolkit/page-heading.html" %}
-            {% endwith %}
+          {% set heading = 'There were no applications' %}
         {% endif %}
+        <h1 class="govuk-heading-l">{{ heading }}</h1>
     </div>
 </div>
 

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -19,14 +19,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <div class="single-question-page">
-
-        {% with
-        heading = form.cancel_reason.label.text,
-        smaller = True
-        %}
-          {% include 'toolkit/page-heading.html' %}
-        {% endwith %}
-
+        <h1 class="govuk-heading-l">{{ form.cancel_reason.label.text }}</h1>
         <form method="POST" action="{{ url_for(request.endpoint, framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <p class="govuk-body">

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -17,9 +17,7 @@
 
     <div class="grid-row">
         <div class="column-two-thirds">
-            {% with heading = "Your requirements" %}
-            {% include 'toolkit/page-heading.html' %}
-            {% endwith %}
+          <h1 class="govuk-heading-xl">Your requirements</h1>
         </div>
     </div>
 

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -20,12 +20,8 @@
 {% block main_content %}
 <div class="grid-row">
   <div class="column-two-thirds">
-    {% with
-        context = current_user.email_address,
-        heading = current_user.name
-    %}
-    {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
+    <span class="govuk-heading-xl">{{ current_user.email_address }}</span>
+    <h1 class="govuk-heading-xl">{{ current_user.name }}</h1>
   </div>
 </div>
 <div class="grid-row">
@@ -44,12 +40,12 @@
           You don't have any saved searches.
         {% endif %}
       </p>
-    
+
       <h2 class="heading-xmedium">Digital outcomes, specialists and user research participants</h2>
       <p class="govuk-body">
         {% if user_briefs_total %}
-          <a class="govuk-link" href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>  
-        {% else %}   
+          <a class="govuk-link" href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>
+        {% else %}
           You don't have any requirements.
         {% endif %}
       </p>

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -17,14 +17,8 @@
 
     {% block before_heading %}{% endblock %}
     <div class="column-two-thirds">
-      {% with
-        heading = section.name,
-        smaller = true,
-        context = brief.get('title', brief['lotName'])
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-
+      <span class="govuk-caption-l">{{ brief.get('title', brief['lotName']) }}</span>
+      <h1 class="govuk-heading-l">{{ section.name }}</h1>
     </div>
 
     {% if section.description %}

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -29,12 +29,7 @@
 
 <div class="grid-row">
     <div class="column-two-thirds large-paragraph">
-        {% with
-          smaller = true,
-          heading = title_text
-        %}
-        {% include 'toolkit/page-heading.html' %}
-        {% endwith %}
+      <h1 class="govuk-heading-l">{{ title_text }}</h1>
     </div>
 
     <div class="column-two-thirds large-paragraph">

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -21,12 +21,7 @@
 
 <div class="grid-row">
     <div class="column-two-thirds large-paragraph">
-        {% with
-        smaller = true,
-        heading = "Find a user research lab"
-        %}
-        {% include 'toolkit/page-heading.html' %}
-        {% endwith %}
+      <h1 class="govuk-heading-l">Find a user research lab</h1>
     </div>
 
     <div class="column-two-thirds large-paragraph">

--- a/app/templates/buyers/supplier_questions.html
+++ b/app/templates/buyers/supplier_questions.html
@@ -17,14 +17,10 @@
 
     {% block before_heading %}{% endblock %}
     <div class="column-two-thirds">
-      {% with
-        heading = "Supplier questions",
-        smaller = true,
-        context = brief.get('title', brief['lotName'])
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-
+      <span class="govuk-caption-l">{{ brief.get('title', brief['lotName']) }}</span>
+      <h1 class="govuk-heading-l">
+        Supplier questions
+      </h1>
     </div>
 
     <div class="column-one-whole">

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -24,13 +24,9 @@
   {% include "toolkit/forms/validation.html" %}
 {% endwith %}
 
-{%
-  with
-    smaller = true,
-    heading = "Create a buyer account"
-%}
-{% include "toolkit/page-heading.html" %}
-{% endwith %}
+<h1 class="govuk-heading-l">
+  Create a buyer account
+</h1>
 
 <p class="govuk-body-l">
   You must be employed by, or represent, a public sector organisation.

--- a/app/templates/create_buyer/create_buyer_user_error.html
+++ b/app/templates/create_buyer/create_buyer_user_error.html
@@ -10,9 +10,10 @@
 
   <div class="grid-row">
     <div class="column-two-thirds error-page">
-      <header class="page-heading-smaller">
-        <h1>You must use a public sector email address</h1>
-      </header>
+      <h1 class="govuk-heading-l">
+        You must use a public sector email address
+      </h1>
+
       <p class="govuk-body">
         You must be employed by, or represent, a public sector organisation to create a buyer account.
       </p>
@@ -38,10 +39,9 @@
   </div>
 
 {% elif not token %}
-
-  <header class="page-heading-smaller">
-    <h1>Expired link</h1>
-  </header>
+  <h1 class="govuk-heading-l">
+    Expired link
+  </h1>
   <p class="govuk-body">
     The link you used to create an account may have expired.<br/>
     Check you’ve entered the correct link or <a class="govuk-link" href="{{ url_for('.create_buyer_account') }}">send a new one</a>.<br/>
@@ -51,28 +51,25 @@
 {% elif user %}
 
   {% if not user.active %}
-
-    <header class="page-heading-smaller">
-      <h1>Your account has been deactivated.</h1>
-    </header>
+    <h1 class="govuk-heading-l">
+      Your account has been deactivated.
+    </h1>
     <p class="govuk-body">
       Email <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to reactivate your account.
     </p>
 
   {% elif user.locked %}
-
-    <header class="page-heading-smaller">
-      <h1>Your account has been locked.</h1>
-    </header>
+    <h1 class="govuk-heading-l">
+      Your account has been locked.
+    </h1>
     <p class="govuk-body">
       Email <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to unlock your account.
     </p>
 
   {% elif user.role == 'supplier' %}
-
-    <header class="page-heading-smaller">
-      <h1>The details you provided are registered with a supplier.</h1>
-    </header>
+    <h1 class="govuk-heading-l">
+      The details you provided are registered with a supplier.
+    </h1>
     <p class="govuk-body">Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
     <p class="govuk-body">You can <a class="govuk-link" href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
       <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to have your account
@@ -82,10 +79,7 @@
     </p>
 
   {% else %}
-
-    <header class="page-heading-smaller">
-      <h1>Account already exists</h1>
-    </header>
+    <h1 class="govuk-heading-l">Account already exists</h1>
 
     <p class="govuk-body">
       <a class="govuk-link" href="{{ url_for('external.render_login') }}">Log in</a> to your account.

--- a/app/templates/create_buyer/create_your_account_complete.html
+++ b/app/templates/create_buyer/create_your_account_complete.html
@@ -21,13 +21,7 @@
 {% block main_content %}
 
 <div class="single-question-page">
-  {%
-    with
-      heading = "Activate your account"
-  %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
+  <h1 class="govuk-heading-xl">Activate your account</h1>
   <div class="grid-row">
     <div class="column-two-thirds">
       <p class="govuk-body">


### PR DESCRIPTION
This replaces toolkit/page-headings with govuk frontend page titles.

Generally, the headings were `h1` with a css class of `govuk-heading-xl`.
These were the mappings I used while replacing

Generally, use `govuk-heading-xl` class
If "smaller : true" when calling toolkit/page-heading, is `h1` with
`govuk-heading-l`.
If "Context" used when calling toolkit/page-heading, add span above the
`h1` and use govuk-caption-xl or govuk-caption-l depending on the heading
used.

ticket: https://trello.com/c/nxvnWqtc