### PR TITLE
DOS Preview feature: add links for Preview env only

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from flask import abort, request, redirect, url_for, flash
+from flask import abort, request, redirect, url_for, flash, current_app
 from flask_login import current_user
 
 from app import data_api_client
@@ -228,6 +228,67 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
 
     breadcrumbs = get_briefs_breadcrumbs()
 
+    # Temporary additional link for Preview feature
+    if current_app.config['SHOW_DOS_PREVIEW_LINKS']:
+        publish_requirements_section_links = [
+            {
+                'href': url_for(
+                    ".review_brief",
+                    framework_slug=brief['frameworkSlug'],
+                    lot_slug=brief['lotSlug'],
+                    brief_id=brief['id']
+                ),
+                'text': 'Preview your requirements',
+                'allowed_statuses': ['draft']
+            },
+            {
+                'href': url_for(
+                    ".publish_brief",
+                    framework_slug=brief['frameworkSlug'],
+                    lot_slug=brief['lotSlug'],
+                    brief_id=brief['id']
+                ),
+                'text': 'Publish your requirements',
+                'allowed_statuses': ['draft']
+            }
+        ]
+    else:
+        publish_requirements_section_links = [
+            {
+                'href': url_for(
+                    ".publish_brief",
+                    framework_slug=brief['frameworkSlug'],
+                    lot_slug=brief['lotSlug'],
+                    brief_id=brief['id']
+                ),
+                'text': 'Review and publish your requirements',
+                'allowed_statuses': ['draft']
+            }
+        ]
+
+    # Shared links
+    publish_requirements_section_links.extend([
+        {
+            'href': url_for(
+                ".view_brief_timeline",
+                framework_slug=brief['frameworkSlug'],
+                lot_slug=brief['lotSlug'],
+                brief_id=brief['id']
+            ),
+            'text': 'View question and answer dates',
+            'allowed_statuses': ['live']
+        },
+        {
+            'href': url_for(
+                "external.get_brief_by_id",
+                framework_family=brief['framework']['family'],
+                brief_id=brief['id']
+            ),
+            'text': 'View your published requirements',
+            'allowed_statuses': ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful']
+        }
+    ])
+
     return render_template(
         "buyers/brief_overview.html",
         framework=framework,
@@ -241,7 +302,8 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
         call_off_contract_url=call_off_contract_url,
         framework_agreement_url=framework_agreement_url,
         awarded_brief_response_supplier_name=awarded_brief_response_supplier_name,
-        breadcrumbs=breadcrumbs
+        breadcrumbs=breadcrumbs,
+        publish_requirements_section_links=publish_requirements_section_links
     ), 200
 
 

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -339,11 +339,19 @@ def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug)
         }
     ])
 
+    # Show DOS preview link if feature flag set, and all mandatory questions have been answered
+    show_dos_preview_link = False
+    if current_app.config['SHOW_DOS_PREVIEW_LINKS'] is True:
+        unanswered_required, unanswered_optional = count_unanswered_questions(sections)
+        if unanswered_required == 0:
+            show_dos_preview_link = True
+
     return render_template(
         "buyers/section_summary.html",
         brief=brief,
         section=section,
         breadcrumbs=breadcrumbs,
+        show_dos_preview_link=show_dos_preview_link
     ), 200
 
 

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -111,23 +111,7 @@
                 'cancelled': 'Done',
                 'unsuccessful': 'Done',
               },
-              'links': [
-                {
-                  'href': url_for(".publish_brief",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                  'text': 'Review and publish your requirements',
-                  'allowed_statuses': ['draft']
-                },
-                {
-                  'href': url_for(".view_brief_timeline",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                  'text': 'View question and answer dates',
-                  'allowed_statuses': ['live']
-                },
-                {
-                  'href': url_for("external.get_brief_by_id", framework_family=brief.framework.family, brief_id=brief.id),
-                  'text': 'View your published requirements',
-                  'allowed_statuses': ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful']
-                }
-              ]
+              'links': publish_requirements_section_links
             },
             {
               'title': 'Answer supplier questions',

--- a/app/templates/buyers/review_brief.html
+++ b/app/templates/buyers/review_brief.html
@@ -6,18 +6,7 @@
 
 {% block breadcrumb %}
   {%
-    with
-    items = [
-      {
-          "link": url_for('external.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-          "link": url_for('external.list_opportunities', framework_family=brief.framework.family),
-          "label": "Supplier opportunities"
-      },
-      breadcrumbs
-    ]
+    with items = breadcrumbs
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}

--- a/app/templates/buyers/review_brief.html
+++ b/app/templates/buyers/review_brief.html
@@ -29,7 +29,7 @@
 <div class="govuk-grid-row">
   <div class="column-two-thirds">
     <header class="page-heading-smaller">
-      <h1>Review your requirements</h1>
+      <h1>Preview your requirements</h1>
     </header>
   </div>
 </div>

--- a/app/templates/buyers/review_brief.html
+++ b/app/templates/buyers/review_brief.html
@@ -74,7 +74,9 @@
         }) }}
       </div>
     </div>
-
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ url_for('.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Return to overview</a>
+    </p>
   </div>
 </div>
 

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -88,6 +88,16 @@
 
   </div>
 
+  {% if show_dos_preview_link %}
+    {%
+      with
+      url = url_for(".review_brief", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+      text = "Preview your requirements"
+    %}
+      {% include "toolkit/secondary-action-link.html" %}
+    {% endwith %}
+  {% endif %}
+
   {%
     with
     url = url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),

--- a/config.py
+++ b/config.py
@@ -74,6 +74,9 @@ class Config(object):
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader
 
+    # Feature flag - show on Preview and Local only for now
+    SHOW_DOS_PREVIEW_LINKS = False
+
 
 class Test(Config):
     DEBUG = True
@@ -101,6 +104,9 @@ class Development(Config):
     SECRET_KEY = "verySecretKey"
     SHARED_EMAIL_KEY = "very_secret"
 
+    # Feature flag for DOS preview
+    SHOW_DOS_PREVIEW_LINKS = True
+
 
 class Live(Config):
     """Base config for deployed environments"""
@@ -117,7 +123,8 @@ class Live(Config):
 
 
 class Preview(Live):
-    pass
+    # Feature flag for DOS preview
+    SHOW_DOS_PREVIEW_LINKS = True
 
 
 class Staging(Live):


### PR DESCRIPTION
https://trello.com/c/73Tb7aJa/67-2-include-dos-preview-page-in-the-buyer-journey

Small tweaks to the Preview page itself:
- Renames the title of the page to 'Preview your requirements' 
- Fixes breadcrumbs on review page, so buyers can always return to the brief overview
- 'Return to Overview' links are now at both the top and bottom of the preview panes

To include the Preview page in the journey:
- Adds a feature flag `SHOW_DOS_PREVIEW_LINKS`, enabled only for Preview and Local environments for now
- Add logic in the `brief_overview` and `edit_section` views to determine whether to show a link to the Preview functionality. All mandatory questions must be answered, and the feature flag must be set. 
- For the brief_overview, include the preview and publish actions as separate links, instead of the single `Review and publish your requirements` link (see below).

Brief overview page:
![preview-and-publish-links-overview](https://user-images.githubusercontent.com/3492540/69140623-be3bb400-0aba-11ea-9c01-1ddc9e8bc1e6.png)

