### PR TITLE
Add Python 3.7 and 3.8 checks to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 before_install:
   - nvm install
 install:

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,7 +6,7 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.7.0#egg=digitalmarketplace-utils==48.7.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ coveralls==1.8.1
 cssselect==1.0.3
 flake8==3.7.7
 freezegun==0.3.12
-lxml==4.3.4
+lxml==4.4.1
 mock==3.0.5
 pytest==4.6.3
 pytest-cov==2.7.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ pytest-cov==2.7.1
 python-dotenv==0.10.3  # used to load .flaskenv
 watchdog==0.9.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.1.2#egg=digitalmarketplace-test-utils==2.1.2
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,18 +7,18 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.7.0#egg=digitalmarketplace-utils==48.7.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
 
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.7
-botocore==1.13.7
+boto3==1.10.23
+botocore==1.13.23
 certifi==2019.9.11
-cffi==1.13.1
+cffi==1.13.2
 chardet==3.0.4
 Click==7.0
 contextlib2==0.6.0.post1
@@ -51,9 +51,9 @@ pytz==2019.3
 PyYAML==5.1.2
 requests==2.22.0
 s3transfer==0.2.1
-six==1.12.0
+six==1.13.0
 unicodecsv==0.14.1
-urllib3==1.25.6
-Werkzeug==0.15.6
+urllib3==1.25.7
+Werkzeug==0.16.0
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

- Bumps content loader, utils, test utils and API client
- Adds 3.7 and 3.8 to Travis config

(Also bumps Werkzeug, superseding https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/242)