### PR TITLE
DOS preview tweaks

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -531,11 +531,6 @@ def review_brief(framework_slug, lot_slug, brief_id):
 
     content = content_loader.get_manifest(brief['frameworkSlug'], 'edit_brief').filter({'lot': brief['lotSlug']})
 
-    # Check that all questions have been answered
-    unanswered_required, unanswered_optional = count_unanswered_questions(content.summary(brief))
-    if unanswered_required > 0:
-        abort(400, 'There are still unanswered required questions')
-
     breadcrumbs = get_briefs_breadcrumbs([
         {
             "link": url_for(
@@ -546,6 +541,17 @@ def review_brief(framework_slug, lot_slug, brief_id):
             "label": brief['title']
         }
     ])
+
+    # Check that all questions have been answered
+    unanswered_required, unanswered_optional = count_unanswered_questions(content.summary(brief))
+    if unanswered_required > 0:
+        return render_template(
+            "buyers/review_brief.html",
+            content=content,
+            unanswered_required=unanswered_required,
+            brief=brief,
+            breadcrumbs=breadcrumbs
+        ), 400
 
     return render_template(
         "buyers/review_brief.html",

--- a/app/templates/buyers/review_brief.html
+++ b/app/templates/buyers/review_brief.html
@@ -25,55 +25,74 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <p class="govuk-body">This is how suppliers will see your requirements when they are published.</p>
-    <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Return to overview</a>
-    </p>
 
-    {% set desktopHtml %}
-      <iframe
-        src="{{ url_for('.review_brief_source', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}"
-        title="Preview of the page on desktop or tablet"
-        class="dm-desktop-iframe"
-      >
-      </iframe>
-    {% endset %}
-    {% set mobileHtml %}
-      <div class="dm-mobile-preview">
+    {% if unanswered_required %}
+      <div class="dmspeak">
+        <p class="govuk-body">You still need to complete the following questions before your requirements can be previewed:</p>
+      </div>
+      {% for section in content.summary(brief) %}
+        {% for question in section.questions %}
+          {% if question.answer_required and not question.id == 'requirementsLength' %}
+            <ol class="govuk-list govuk-list--number">
+              <li>
+                <a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
+              </li>
+            </ol>
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+    {% else %}
+      <p class="govuk-body">This is how suppliers will see your requirements when they are published.</p>
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ url_for('.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Return to overview</a>
+      </p>
+
+      {% set desktopHtml %}
         <iframe
           src="{{ url_for('.review_brief_source', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}"
-          title="Preview of the page on mobile"
-          class="dm-mobile-iframe"
+          title="Preview of the page on desktop or tablet"
+          class="dm-desktop-iframe"
         >
         </iframe>
-      </div>
-    {% endset %}
+      {% endset %}
+      {% set mobileHtml %}
+        <div class="dm-mobile-preview">
+          <iframe
+            src="{{ url_for('.review_brief_source', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}"
+            title="Preview of the page on mobile"
+            class="dm-mobile-iframe"
+          >
+          </iframe>
+        </div>
+      {% endset %}
 
-    {% set pageTabs = [
-      {
-        "label": "Desktop",
-        "id": "desktop-preview",
-        "panel": {
-          "html": desktopHtml
-        }
-      },
-      {
-        "label": "Mobile",
-        "id": "mobile-preview",
-        "panel": {
-          "html": mobileHtml
-        }
-      },
-    ] %}
+      {% set pageTabs = [
+        {
+          "label": "Desktop",
+          "id": "desktop-preview",
+          "panel": {
+            "html": desktopHtml
+          }
+        },
+        {
+          "label": "Mobile",
+          "id": "mobile-preview",
+          "panel": {
+            "html": mobileHtml
+          }
+        },
+      ] %}
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        {{ govukTabs({
-          "title": "Review your requirements",
-          "items": pageTabs
-        }) }}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          {{ govukTabs({
+            "title": "Review your requirements",
+            "items": pageTabs
+          }) }}
+        </div>
       </div>
-    </div>
+    {% endif %}
+
     <p class="govuk-body">
       <a class="govuk-link" href="{{ url_for('.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Return to overview</a>
     </p>

--- a/app/templates/buyers/review_brief_source.html
+++ b/app/templates/buyers/review_brief_source.html
@@ -28,6 +28,8 @@
 </div>
 
 {% endblock %}
+{% block after_header %}
+{% endblock %}
 {% block breadcrumb %}
   {%
     with

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1089,6 +1089,30 @@ class TestReviewBrief(BaseApplicationTest):
                               "digital-specialists/1234/review")
         assert res.status_code == 400
 
+        page_html = res.get_data(as_text=True)
+        document = html.fromstring(page_html)
+
+        # Show link to the the unanswered question
+        assert 'You still need to complete the following questions before your requirements can be previewed:' in \
+               page_html
+        assert len(document.xpath(
+            "//a[@href=$u][normalize-space(string())=$t]",
+            u="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/"
+              "digital-specialists/1234/edit/shortlist-and-evaluation-process/technicalCompetenceCriteriaSpecialists",
+            t="Technical competence criteria",
+        )) == 1
+
+        # Don't show the preview tabs
+        assert "This is how suppliers will see your requirements when they are published." not in page_html
+        preview_src_link = "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/" \
+                           "digital-specialists/1234/review-source"
+        assert len(document.xpath(
+            "//iframe[@src=$u][@title=$t][@class=$c]",
+            u=preview_src_link,
+            t="Preview of the page on desktop or tablet",
+            c="dm-desktop-iframe"
+        )) == 0
+
     def test_review_source_page_400s_if_unanswered_questions(self):
         brief_json = self._setup_brief()
         brief_json['briefs'].pop('essentialRequirements')


### PR DESCRIPTION
https://trello.com/c/j817455O/140-run-5x-usability-tests-for-new-preview-feature

Addresses some minor bugfixes found during user testing. 

- Always hide the user research banner within the preview panel
- If there are unanswered questions, instead of showing a 400 error, replicate the [functionality on the publish page](https://github.com/alphagov/digitalmarketplace-briefs-frontend/blob/master/app/templates/buyers/brief_publish_confirmation.html#L52), and show links to the unanswered questions (see below):

![dos-preview-unanswered-questions](https://user-images.githubusercontent.com/3492540/69562294-c4440000-0fa6-11ea-9efe-f3ca37bbe46e.png)
