### PR TITLE
Fix caption for buyer account page

### DIFF
--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -20,7 +20,7 @@
 {% block main_content %}
 <div class="grid-row">
   <div class="column-two-thirds">
-    <span class="govuk-heading-xl">{{ current_user.email_address }}</span>
+    <span class="govuk-caption-xl">{{ current_user.email_address }}</span>
     <h1 class="govuk-heading-xl">{{ current_user.name }}</h1>
   </div>
 </div>


### PR DESCRIPTION
Small typo I missed in reviewing #241 makes big difference :sweat_smile:

Fortunately our smoke tests caught it! Unfortunately that means I've had to disable our smoke tests...

## Screenshots

### Before

![screenshot of buyer account page with heading caption as govuk-heading-xl](https://user-images.githubusercontent.com/503614/69750099-d1e2bc80-1143-11ea-878c-ea50112e8c7e.png)

### After

![screenshot of buyer account page with heading caption as govuk-caption-xl](https://user-images.githubusercontent.com/503614/69750138-f2ab1200-1143-11ea-811f-38a670c0cfb1.png)

