### PR TITLE
Open DOS preview links in a new tab

### DIFF
--- a/app/templates/buyers/review_brief.html
+++ b/app/templates/buyers/review_brief.html
@@ -43,6 +43,7 @@
       {% endfor %}
     {% else %}
       <p class="govuk-body">This is how suppliers will see your requirements when they are published.</p>
+      <p class="govuk-body">Links will open in a new tab.</p>
       <p class="govuk-body">
         <a class="govuk-link" href="{{ url_for('.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Return to overview</a>
       </p>

--- a/app/templates/buyers/review_brief_source.html
+++ b/app/templates/buyers/review_brief_source.html
@@ -118,7 +118,7 @@
     ) %}
       {% call summary.row() %}
         {{ summary.field_name(item.label) }}
-        {% with item_value = summary[item.type](item.value) | format_links %}
+        {% with item_value = summary[item.type](item.value) | format_links(open_links_in_new_tab=True) %}
             {{ (item_value | preserve_line_breaks) if item.type == 'textbox_large' else item_value }}
         {% endwith %}
       {% endcall %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,7 +6,7 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.2.1#egg=digitalmarketplace-utils==50.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.2.1#egg=digitalmarketplace-utils==50.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
@@ -15,9 +15,9 @@ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.23
-botocore==1.13.23
-certifi==2019.9.11
+boto3==1.10.33
+botocore==1.13.33
+certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 Click==7.0
@@ -48,7 +48,7 @@ PyJWT==1.7.1
 python-dateutil==2.8.0
 python-json-logger==0.1.11
 pytz==2019.3
-PyYAML==5.1.2
+PyYAML==5.2
 requests==2.22.0
 s3transfer==0.2.1
 six==1.13.0

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1257,6 +1257,23 @@ class TestReviewBrief(BaseApplicationTest):
             t=disabled_link_text,
         )) == count
 
+    def test_review_source_page_will_open_user_generated_links_in_a_new_tab(self):
+        brief_json = self._setup_brief()
+        brief_json['briefs']['summary'] = "A link to the full summary: https://www.example.com"
+        self.data_api_client.get_brief.return_value = brief_json
+        res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/"
+                              "digital-specialists/1234/review-source")
+        page_html = res.get_data(as_text=True)
+        document = html.fromstring(page_html)
+
+        assert len(document.xpath(
+            "//a[@href=$u][@target=$b][@rel=$r][normalize-space(string())=$t]",
+            u="https://www.example.com",
+            b="_blank",
+            r="external noreferrer noopener",
+            t="https://www.example.com",
+        )) == 1
+
     def test_review_page_xframe_options_header_not_set(self):
         self.data_api_client.get_brief.return_value = self._setup_brief()
         res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/"


### PR DESCRIPTION
https://trello.com/c/WSCRVNH8/149-allow-buyers-to-preview-external-links-on-their-brief

For the DOS preview feature, we want to allow buyers to check whether links in their brief content work OK. These links generally go to a 3rd party site (e.g. a public Google drive doc).

We already use a template filter `format_links` which picks up plain text URIs like `http://example.com` in user-generated content, and converts them to anchor links `<a href="http://example.com" class="break-link" rel="external">http://example.com</a>`. However in the DOS preview, these links would currently open within the iframe, and it's unlikely they would display correctly (e.g if the site being linked to has disabled the `X-Frame-Options` header - we can't control this). Therefore we want the links to open in a new tab.

In https://github.com/alphagov/digitalmarketplace-utils/pull/546 we modified `format_links` to accept a parameter `open_links_in_new_tab`. It seems to work! I've also tested that the published brief then opens the link in the current window, as per the current behaviour.

The [WCAG guidelines](https://www.w3.org/TR/WCAG20-TECHS/G200.html) say there should be a warning about any opening-in-new-tab behaviour. It doesn't feel suitable to put this next to the links in the preview pane itself (as suppliers won't see that message when it's published) so I've added a line of content above the panel.