### PR TITLE
Remove feature flag for DOS Preview

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from flask import abort, request, redirect, url_for, flash, current_app
+from flask import abort, request, redirect, url_for, flash
 from flask_login import current_user
 
 from app import data_api_client
@@ -228,46 +228,27 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
 
     breadcrumbs = get_briefs_breadcrumbs()
 
-    # Temporary additional link for Preview feature
-    if current_app.config['SHOW_DOS_PREVIEW_LINKS']:
-        publish_requirements_section_links = [
-            {
-                'href': url_for(
-                    ".preview_brief",
-                    framework_slug=brief['frameworkSlug'],
-                    lot_slug=brief['lotSlug'],
-                    brief_id=brief['id']
-                ),
-                'text': 'Preview your requirements',
-                'allowed_statuses': ['draft']
-            },
-            {
-                'href': url_for(
-                    ".publish_brief",
-                    framework_slug=brief['frameworkSlug'],
-                    lot_slug=brief['lotSlug'],
-                    brief_id=brief['id']
-                ),
-                'text': 'Publish your requirements',
-                'allowed_statuses': ['draft']
-            }
-        ]
-    else:
-        publish_requirements_section_links = [
-            {
-                'href': url_for(
-                    ".publish_brief",
-                    framework_slug=brief['frameworkSlug'],
-                    lot_slug=brief['lotSlug'],
-                    brief_id=brief['id']
-                ),
-                'text': 'Review and publish your requirements',
-                'allowed_statuses': ['draft']
-            }
-        ]
-
-    # Shared links
-    publish_requirements_section_links.extend([
+    publish_requirements_section_links = [
+        {
+            'href': url_for(
+                ".preview_brief",
+                framework_slug=brief['frameworkSlug'],
+                lot_slug=brief['lotSlug'],
+                brief_id=brief['id']
+            ),
+            'text': 'Preview your requirements',
+            'allowed_statuses': ['draft']
+        },
+        {
+            'href': url_for(
+                ".publish_brief",
+                framework_slug=brief['frameworkSlug'],
+                lot_slug=brief['lotSlug'],
+                brief_id=brief['id']
+            ),
+            'text': 'Publish your requirements',
+            'allowed_statuses': ['draft']
+        },
         {
             'href': url_for(
                 ".view_brief_timeline",
@@ -287,7 +268,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
             'text': 'View your published requirements',
             'allowed_statuses': ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful']
         }
-    ])
+    ]
 
     return render_template(
         "buyers/brief_overview.html",
@@ -339,12 +320,9 @@ def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug)
         }
     ])
 
-    # Show DOS preview link if feature flag set, and all mandatory questions have been answered
-    show_dos_preview_link = False
-    if current_app.config['SHOW_DOS_PREVIEW_LINKS'] is True:
-        unanswered_required, unanswered_optional = count_unanswered_questions(sections)
-        if unanswered_required == 0:
-            show_dos_preview_link = True
+    # Show preview link if all mandatory questions have been answered
+    unanswered_required, unanswered_optional = count_unanswered_questions(sections)
+    show_dos_preview_link = (unanswered_required == 0)
 
     return render_template(
         "buyers/section_summary.html",

--- a/config.py
+++ b/config.py
@@ -74,9 +74,6 @@ class Config(object):
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader
 
-    # Feature flag - show on Preview and Local only for now
-    SHOW_DOS_PREVIEW_LINKS = False
-
 
 class Test(Config):
     DEBUG = True
@@ -104,9 +101,6 @@ class Development(Config):
     SECRET_KEY = "verySecretKey"
     SHARED_EMAIL_KEY = "very_secret"
 
-    # Feature flag for DOS preview
-    SHOW_DOS_PREVIEW_LINKS = True
-
 
 class Live(Config):
     """Base config for deployed environments"""
@@ -123,8 +117,7 @@ class Live(Config):
 
 
 class Preview(Live):
-    # Feature flag for DOS preview
-    SHOW_DOS_PREVIEW_LINKS = True
+    pass
 
 
 class Staging(Live):

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -5,7 +5,6 @@ from ...helpers import BaseApplicationTest
 from dmapiclient import HTTPError
 from dmtestutils.api_model_stubs import BriefStub, FrameworkStub, LotStub
 from dmcontent.content_loader import ContentLoader
-from flask import current_app
 import mock
 from lxml import html
 import pytest
@@ -1821,7 +1820,8 @@ class TestBriefSummaryPage(BaseApplicationTest):
             'Shortlist and evaluation process',
             'Set how long your requirements will be open for',
             'Describe question and answer session',
-            'Review and publish your requirements',
+            'Preview your requirements',
+            'Publish your requirements',
             'How to answer supplier questions',
             'How to shortlist suppliers',
             'How to evaluate suppliers',
@@ -2167,11 +2167,9 @@ class TestViewBriefSectionSummaryPage(BaseApplicationTest):
         brief = self._setup_brief(lot_slug='digital-specialists')
         self.data_api_client.get_brief.return_value = brief
 
-        with self.app.app_context():
-            current_app.config['SHOW_DOS_PREVIEW_LINKS'] = show_dos_preview_links
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-1"
-            )
+        res = self.client.get(
+            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-1"
+        )
 
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
@@ -2183,15 +2181,11 @@ class TestViewBriefSectionSummaryPage(BaseApplicationTest):
             "I need a thing to do a thing",  # breadcrumbs
             "Return to overview"             # bottom nav link
         ]
-        preview_link = document.xpath(
-            '//a[@href="/buyers/frameworks/digital-outcomes-and-specialists/'
-            'requirements/digital-specialists/1234/preview"]'
+        assert document.xpath(
+            "//a[@href=$u][normalize-space(string())=$t]",
+            u="/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/preview",
+            t="Preview your requirements",
         )
-        if show_dos_preview_links:
-            assert len(preview_link) == 1
-            assert preview_link[0].text_content().strip() == 'Preview your requirements'
-        else:
-            assert len(preview_link) == 0
 
     def test_wrong_lot_get_view_section_summary(self):
         res = self.client.get(


### PR DESCRIPTION
https://trello.com/c/LjBLJMHt/175-take-feature-flag-off-dos-preview-and-include-in-functional-test

Removes the feature flag restriction for DOS Preview links. Now a buyer can view the preview page as long as they've answered all the mandatory questions. If they haven't answered them all, they'll see a list of the unanswered questions (as per the 'publish' page).

Functional test coverage for the new step: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/714