### PR TITLE
Fix ordered list for unanswered questions on DOS preview page

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -47,17 +47,17 @@
       <div class="dmspeak">
         <p class="govuk-body"><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
       </div>
+      <ul class="govuk-list govuk-list--bullet">
       {% for section in sections %}
         {% for question in section.questions %}
           {% if question.answer_required and not question.id == 'requirementsLength' %}
-            <ol class="govuk-list govuk-list--number">
-              <li>
-                <a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
-              </li>
-            </ol>
+            <li>
+              <a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
+            </li>
           {% endif %}
         {% endfor %}
       {% endfor %}
+      </ul>
     {% elif brief.lotSlug != 'digital-specialists' or brief.requirementsLength %}
       {% import "toolkit/summary-table.html" as summary %}
         {% call summary.mapping_table(

--- a/app/templates/buyers/preview_brief.html
+++ b/app/templates/buyers/preview_brief.html
@@ -28,17 +28,17 @@
       <div class="dmspeak">
         <p class="govuk-body">You still need to complete the following questions before your requirements can be previewed:</p>
       </div>
+      <ul class="govuk-list govuk-list--bullet">
       {% for section in content.summary(brief) %}
         {% for question in section.questions %}
           {% if question.answer_required and not question.id == 'requirementsLength' %}
-            <ol class="govuk-list govuk-list--number">
-              <li>
-                <a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
-              </li>
-            </ol>
+            <li>
+              <a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
+            </li>
           {% endif %}
         {% endfor %}
       {% endfor %}
+      </ul>
     {% else %}
       <p class="govuk-body">This is how suppliers see your requirements when they are published.</p>
       <p class="govuk-body">Preview links will open in a new tab.</p>

--- a/app/templates/buyers/preview_brief.html
+++ b/app/templates/buyers/preview_brief.html
@@ -90,13 +90,13 @@
           }) }}
         </div>
       </div>
-    {% endif %}
+
     <form action="{{ url_for('.publish_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="GET">
       {{ govukButton({
         "text": "Confirm your requirements and publish",
       }) }}
     </form>
-
+    {% endif %}
   </div>
 </div>
 

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1101,7 +1101,7 @@ class TestPreviewBrief(BaseApplicationTest):
             t="Technical competence criteria",
         )) == 1
 
-        # Don't show the preview tabs
+        # Don't show the preview tabs or call-to-action button
         assert "This is how suppliers will see your requirements when they are published." not in page_html
         preview_src_link = "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/" \
                            "digital-specialists/1234/preview-source"
@@ -1110,6 +1110,10 @@ class TestPreviewBrief(BaseApplicationTest):
             u=preview_src_link,
             t="Preview of the page on desktop or tablet",
             c="dm-desktop-iframe"
+        )) == 0
+        assert len(document.xpath(
+            "//button[normalize-space(string())=$t]",
+            t="Confirm your requirements and publish",
         )) == 0
 
     def test_preview_source_page_400s_if_unanswered_questions(self):


### PR DESCRIPTION
https://trello.com/c/ty5sSouc/232-dos-preview-error-page-list-numbering

One of our users reported a bug with the DOS Preview - if there are unanswered questions, the list shows with every item numbered '1'. 

There's no actual user need to have the items numbered - those numbers aren't used anywhere else in the journey and might even be confusing, so I've changed to an unordered list. 

Also, the markup had each question as its own `<ol>` (hence the bug), which could be confusing for screenreaders etc. This code was copied from the `brief_publish_confirmation.html` template, so I've changed both templates to contain a single unordered list.

I also spotted that the call-to-action button was displayed when there were unanswered questions. While this doesn't allow the user to publish, I've changed it to only show when the user is ready to proceed, and included this in the unit test.

**Before**
![Screenshot 2020-01-06 at 15 53 29](https://user-images.githubusercontent.com/3492540/71832489-f5821680-30a2-11ea-9999-0c09284c5f7f.png)

**After**
![dos-preview-bullet-list](https://user-images.githubusercontent.com/3492540/71832361-ab009a00-30a2-11ea-84dc-7c295d834779.png)
 