### PR TITLE
update package-lock.json to address node-sass vulnerability CVE-2018-11695

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7170,9 +7170,9 @@
       }
     },
     "node-sass": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -7181,7 +7181,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",


### PR DESCRIPTION
https://trello.com/c/k3h1X1dP

Please someone check on their local machine.

Update: this is a minor issue that would only be exploitable if someone tricked us into executing their sass. "Checking" just involves running the tests on a local machine - I have a slightly different setup to the rest of you and I want to make sure I haven't screwed up the `package-lock.json`.