### PR TITLE
new error pages and without any tests failing

### DIFF
--- a/config.py
+++ b/config.py
@@ -68,9 +68,12 @@ class Config(object):
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
+        digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
         template_folders = [
             os.path.join(repo_root, 'app', 'templates'),
-            os.path.join(repo_root, 'node_modules', 'digitalmarketplace-govuk-frontend', 'govuk-frontend'),
+            os.path.join(digitalmarketplace_govuk_frontend),
+            os.path.join(digitalmarketplace_govuk_frontend, "digitalmarketplace", "templates"),
+            os.path.join(digitalmarketplace_govuk_frontend, 'govuk-frontend'),
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader

--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,9 +2091,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.2.0.tgz",
-      "integrity": "sha512-sELMElO6SS4MuPYHYEDr0+ZhIg2ZKr2TzWrxm52lcZKuMmgJ2otq3x1aezcZbj7ZXpwdNtoTOrvlTH1xy08bkQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.3.1.tgz",
+      "integrity": "sha512-nw/f5oDTE7L2KboC8ujqw5hyI0B5fkAEh5a6kKnesO4kQl8JOV8rviYfgOcVUzf0MdcwwT9fBUOO2bMPcd13WQ=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.3.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.2.0",
+    "digitalmarketplace-govuk-frontend": "^0.3.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",


### PR DESCRIPTION
trello: https://trello.com/c/maiREbcE/243-1-add-error-page-templates-to-briefs-frontend

I am a little sceptical about this, because no tests failed.