### PR TITLE
Fix govuk-frontend images path

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -46,7 +46,7 @@ $path: "/buyers/static/images/";
 
 // GOV.UK Design System (compatible with old toolkit/elements)
 $govuk-assets-path: '/buyers/static/';
-$govuk-images-path: '/buyers/static/images/govuk-frontend/';
+$govuk-images-path: '/buyers/static/images/';
 $govuk-fonts-path: '/buyers/static/fonts/';
 $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -252,7 +252,7 @@ gulp.task(
   copyFactory(
     'images from the GOVUK frontend',
     govukFrontendImageFolder,
-    staticFolder + '/images/govuk-frontend/'
+    path.join(staticFolder, 'images')
   )
 )
 


### PR DESCRIPTION
We wanted GOV.UK Frontend image assets to be in a separate folder in our
static assets directory structure; however, this doesn't fit with the
[page template for GOV.UK Frontend][1], which expects the favicon (and
other image assets) to be located in `/static/images`.

This commit changes the gulp task and Sass configuration to put GOV.UK
Frontend image assets in this location.

Related to https://trello.com/c/NjfXXwRH/1382-admin-frontend-has-no-favicon

[1]: https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/template.njk#L17