### PR TITLE
Update cookie banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,10 +14,12 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk-frontend/all.js
+//= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/digitalmarketplace-govuk-frontend.js
 //= require _onready.js'
 //= require _selection-buttons.js
 
 GOVUKFrontend.initAll();
+DMGOVUKFrontend.initAll();
 
 (function(GOVUK, GDM) {
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -7,6 +7,7 @@
 {% from "govuk-frontend/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {# Import DM Components #}
+{% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader%}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter%}
 
@@ -19,6 +20,12 @@
 {% endblock %}
 
 {% block header %}
+  {% block cookieBanner %}
+    {{ dmCookieBanner({
+      'cookieSettingsUrl': url_for('external.cookie_settings'),
+      'cookieInfoUrl': url_for('external.cookies'),
+    }) }}
+  {% endblock %}
   {{ dmHeader({
     "role": current_user.role | default(None)
   }) }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,9 +2091,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.4.1.tgz",
-      "integrity": "sha512-SecGO1BzepmOg9z13n5ZHoRIyw1FwrhntI2y5gum3hRFkKf38MwsRHNcq0MzR8HsyIc3UsIGj2pjehJqG7rdUA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.0.tgz",
+      "integrity": "sha512-JuThzUkpgeIRDFfdLnljqZcuz1Ywkzk5lsKdlsrRe20Dg0j8rEuvWhfPJU5rBtcnnyBfoLdILeOXKt55to2lsg=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.3.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.4.1",
+    "digitalmarketplace-govuk-frontend": "^0.6.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,7 +6,7 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.1#egg=digitalmarketplace-utils==51.3.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,18 +7,18 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.1#egg=digitalmarketplace-utils==51.3.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
 
 ## The following requirements were added by pip freeze:
-asn1crypto==1.2.0
+asn1crypto==1.3.0
 blinker==1.4
-boto3==1.10.41
-botocore==1.13.41
+boto3==1.11.13
+botocore==1.14.13
 certifi==2019.11.28
-cffi==1.13.2
+cffi==1.14.0
 chardet==3.0.4
 Click==7.0
 contextlib2==0.6.0.post1
@@ -34,26 +34,26 @@ gds-metrics==0.2.0
 govuk-country-register==0.5.0
 idna==2.8
 inflection==0.3.1
-Jinja2==2.10.3
+Jinja2==2.11.1
 jmespath==0.9.4
 mailchimp3==3.0.6
 Markdown==2.6.11
 MarkupSafe==1.1.1
 monotonic==1.5
-notifications-python-client==5.4.1
-odfpy==1.4.0
+notifications-python-client==5.5.1
+odfpy==1.4.1
 prometheus-client==0.2.0
 pycparser==2.19
 PyJWT==1.7.1
-python-dateutil==2.8.0
+python-dateutil==2.8.1
 python-json-logger==0.1.11
 pytz==2019.3
-PyYAML==5.2
+PyYAML==5.3
 requests==2.22.0
-s3transfer==0.2.1
-six==1.13.0
+s3transfer==0.3.3
+six==1.14.0
 unicodecsv==0.14.1
-urllib3==1.25.7
+urllib3==1.25.8
 Werkzeug==0.16.0
 workdays==1.4
 WTForms==2.2.1

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,5 +1,7 @@
 import mock
+from lxml import html
 from wtforms import ValidationError
+
 from .helpers import BaseApplicationTest
 from dmapiclient.errors import HTTPError
 
@@ -68,3 +70,11 @@ class TestApplication(BaseApplicationTest):
             # POST requests will not preserve the request path on redirect
             assert res.location == 'http://localhost/user/login'
             assert validate_csrf.call_args_list == [mock.call(None)]
+
+    def test_should_use_local_cookie_page_on_cookie_message(self):
+        res = self.client.get('/buyers')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+        cookie_banner = document.xpath('//div[@id="dm-cookie-banner"]')
+        assert cookie_banner[0].xpath('//h2//text()')[0].strip() == "Can we store analytics cookies on your device?"


### PR DESCRIPTION
https://trello.com/c/hGlNERQ6/294-3-cookie-settings-page-incl-analytics-roll-out

Introduces the new opt-in cookie banner.

See equivalent for Buyer FE alphagov/digitalmarketplace-buyer-frontend#986

- pulls in CookieBanner component from DM GOVUK Frontend
- pulls in utils fix for the new external /user/cookie-settings route
- adds banner to base page template
- adds a cookie banner unit test, to bring in line with the other apps.