### PR TITLE
cookie settings link at dashboard and test for it

### DIFF
--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -61,6 +61,10 @@
     </p>
 
     <p class="govuk-body">
+      <a class="govuk-link" href="{{ url_for('external.cookie_settings') }}">Change your cookie settings</a>
+    </p>
+
+    <p class="govuk-body">
       <a
         class="govuk-link"
         href="{{ url_for('external.user_research_consent') }}"

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -2637,6 +2637,11 @@ class TestBuyerAccountOverview(BaseApplicationTest):
             u="/user/change-password",
             t="Change your password",
         )
+        assert document.xpath(
+            "//a[@href=$u][normalize-space(string())=$t]",
+            u="/user/cookie-settings",
+            t="Change your cookie settings",
+        )
 
         assert bool(document.xpath(
             "//a[@href=$u][normalize-space(string())=$t]",


### PR DESCRIPTION
trello: https://trello.com/c/X1LuXpy4/313-add-link-to-cookie-settings-page-on-user-dashboards-1

I'd rather change the paragraph elements on the side into a list. Let me know.