### PR TITLE
Update digitalmarketplace-govuk-frontend to 0.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,9 +2091,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.4.tgz",
-      "integrity": "sha512-5PLbOcJ7jaHyrh3NwIvkww5LeDI7jJ/WA1fpjyjn3MI6dCQP5PNGILkkmP7aRrzXzXVqCkiK/rINVsy/kn3HZA=="
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.5.tgz",
+      "integrity": "sha512-lc1rpQhML7hzVy2wdVudEIrZ/OCo4Sl5LRC2lcjKdolK9AR9Oaev6xWSNpd7LgCqmvRafYOHhFl2aV70C2cW7g=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.3.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.6.4",
+    "digitalmarketplace-govuk-frontend": "^0.6.5",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Ticket: https://trello.com/c/2DCSrTeq/1451-fix-the-frameword

Includes fixes for cookie banner buttons and typo in footer