### PR TITLE
Update error messages for /buyer/create

### DIFF
--- a/app/create_buyer/forms/auth_forms.py
+++ b/app/create_buyer/forms/auth_forms.py
@@ -8,7 +8,7 @@ class EmailAddressForm(FlaskForm):
     email_address = DMStripWhitespaceStringField(
         "Your email address",
         validators=[
-            DataRequired(message="You must provide an email address"),
-            ValidEmailAddress(message="You must provide a valid email address"),
+            DataRequired(message="Enter an email address"),
+            ValidEmailAddress(message="Enter an email address in the correct format, like name@example.gov.uk"),
         ]
     )

--- a/tests/create_buyers/views/test_create_buyers.py
+++ b/tests/create_buyers/views/test_create_buyers.py
@@ -64,7 +64,7 @@ class TestBuyersCreation(BaseApplicationTest):
         assert res.status_code == 400
         data = res.get_data(as_text=True)
         assert 'Create a buyer account' in data
-        assert 'You must provide a valid email address' in data
+        assert 'Enter an email address in the correct format, like name@example.gov.uk' in data
 
     def test_should_raise_validation_error_for_email_address_with_two_at_symbols(self):
         res = self.client.post(
@@ -75,7 +75,7 @@ class TestBuyersCreation(BaseApplicationTest):
         assert res.status_code == 400
         data = res.get_data(as_text=True)
         assert 'Create a buyer account' in data
-        assert 'You must provide a valid email address' in data
+        assert 'Enter an email address in the correct format, like name@example.gov.uk' in data
 
     def test_should_raise_validation_error_for_empty_email_address(self):
         res = self.client.post(
@@ -86,7 +86,7 @@ class TestBuyersCreation(BaseApplicationTest):
         assert res.status_code == 400
         data = res.get_data(as_text=True)
         assert 'Create a buyer account' in data
-        assert 'You must provide an email address' in data
+        assert 'Enter an email address' in data
 
     def test_should_show_error_page_for_unrecognised_email_domain(self):
         self.data_api_client.is_email_address_with_valid_buyer_domain.return_value = False


### PR DESCRIPTION
https://trello.com/c/Yy3pBfww/13-1-review-error-messages-for-create-a-buyer-account-journey-in-briefs-frontend

Update the form error messages on /buyer/create/<token> to follow [GOV.UK Design System guidance](https://design-system.service.gov.uk/components/error-message/#be-clear-and-concise).