### PR TITLE
Replace validation banner with GOV.UK Frontend error summary component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,7 +8,6 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/option-select.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js

--- a/app/main/forms/award_or_cancel.py
+++ b/app/main/forms/award_or_cancel.py
@@ -11,7 +11,7 @@ class AwardOrCancelBriefForm(FlaskForm):
         ('back', 'We are still evaluating suppliers'),
     ]
     award_or_cancel_decision = RadioField(
-        validators=[validators.InputRequired(message='You need to answer this question.')],
+        validators=[validators.InputRequired(message='Select if you have awarded a contract.')],
         choices=choices
     )
 

--- a/app/main/forms/awards.py
+++ b/app/main/forms/awards.py
@@ -8,7 +8,7 @@ class AwardedBriefResponseForm(FlaskForm):
     # BriefResponse choices expected to be set at runtime
     brief_response = RadioField(
         "Winning BriefResponse",
-        validators=[validators.DataRequired(message="You need to answer this question.")],
+        validators=[validators.DataRequired(message="Select a supplier.")],
         coerce=int
     )
 

--- a/app/main/forms/cancel.py
+++ b/app/main/forms/cancel.py
@@ -10,7 +10,7 @@ class CancelBriefForm(FlaskForm):
         ('unsuccessful', 'There were no suitable suppliers'),
     ]
     cancel_reason = RadioField(
-        validators=[validators.InputRequired(message='You need to answer this question.')],
+        validators=[validators.InputRequired(message='Select a reason for cancelling the brief.')],
         choices=choices
     )
 

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -20,6 +20,7 @@ from dmapiclient import HTTPError
 from dmutils.dates import get_publishing_dates
 from dmutils.flask import timed_render_template as render_template
 from dmutils.formats import DATETIME_FORMAT
+from dmutils.forms.errors import govuk_errors
 from datetime import datetime
 
 from collections import Counter
@@ -127,7 +128,7 @@ def create_new_brief(framework_slug, lot_slug):
         )["briefs"]
     except HTTPError as e:
         update_data = section.unformat_data(update_data)
-        errors = section.get_error_messages(e.message)
+        errors = govuk_errors(section.get_error_messages(e.message))
 
         return render_template(
             "buyers/create_brief_question.html",
@@ -364,7 +365,7 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id, ques
         )
     except HTTPError as e:
         update_data = section.unformat_data(update_data)
-        errors = section.get_error_messages(e.message)
+        errors = govuk_errors(section.get_error_messages(e.message))
 
         # we need the brief_id to build breadcrumbs and the update_data to fill in the form.
         brief.update(update_data)

--- a/app/main/views/outcome.py
+++ b/app/main/views/outcome.py
@@ -15,6 +15,7 @@ from ..forms.award_or_cancel import AwardOrCancelBriefForm
 
 from dmapiclient import HTTPError
 from dmutils.flask import timed_render_template as render_template
+from dmutils.forms.errors import govuk_errors
 from dmutils.forms.helpers import get_errors_from_wtform
 
 BRIEF_UPDATED_MESSAGE = "You’ve updated ‘{brief[title]}’"
@@ -239,7 +240,9 @@ def award_brief_details(framework_slug, lot_slug, brief_id, brief_response_id):
             )
         except HTTPError as e:
             award_data = section.unformat_data(award_data)
-            errors = section.get_error_messages(e.message)
+            errors = govuk_errors(
+                section.get_error_messages(e.message)
+            )
 
             return render_template(
                 "buyers/award_details.html",

--- a/app/main/views/supplier_questions.py
+++ b/app/main/views/supplier_questions.py
@@ -10,6 +10,7 @@ from ..helpers.buyers_helpers import get_framework_and_lot, is_brief_correct
 
 from dmapiclient import HTTPError
 from dmutils.flask import timed_render_template as render_template
+from dmutils.forms.errors import govuk_errors
 
 
 @main.route(
@@ -75,7 +76,7 @@ def add_supplier_question(framework_slug, lot_slug, brief_id):
             if e.status_code != 400:
                 raise
             brief.update(update_data)
-            errors = section.get_error_messages(e.message)
+            errors = govuk_errors(section.get_error_messages(e.message))
             status_code = 400
 
     return render_template(

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,5 +1,7 @@
 {% extends "govuk-frontend/template.njk" %}
 
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+
 {# Import GOV.UK Frontend components for globale usage#}
 {% from "govuk-frontend/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk-frontend/components/button/macro.njk" import govukButton %}
@@ -45,6 +47,14 @@
 
 {% block content %}
   {% include "toolkit/flash_messages.html" %}
+  {% block errorSummary %}
+    {% if errors %}
+      {{ govukErrorSummary({
+      "titleText": "There is a problem",
+      "errorList": errors.values(),
+    }) }}
+    {% endif %}
+  {% endblock %}
   {% block mainContent %}{% endblock %}
 {% endblock %}
 

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -19,8 +19,6 @@
     </div>
   </div>
 
-  {% include 'toolkit/forms/validation.html' %}
-
   <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
 
     <div class="govuk-grid-row">

--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -36,7 +36,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include 'toolkit/forms/validation.html' %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
           <div class="single-question-page">

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -37,19 +37,18 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Tell us about your contract with {{ pending_brief_response.supplierName }}</h1>
       <form method="POST" action="{{ url_for('.award_brief_details', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, brief_response_id=pending_brief_response.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {% for question in section.questions %}
-              {{ forms[question.type](
-                  question,
-                  data,
-                  errors if errors and (errors[question.id] or question.type == 'multiquestion') else {},
-                 )
-              }}
+            {{ forms[question.type](
+                question,
+                data,
+                errors if errors and (errors[question.id] or question.type == 'multiquestion') else {},
+                )
+            }}
           {% endfor %}
 
           {% block save_button %}

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -38,7 +38,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="single-question-page">

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -37,7 +37,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="single-question-page">

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -20,9 +20,6 @@
 
 {% block mainContent %}
 
-{% with lede = "There was a problem with the details you gave for:" %}
-  {% include "toolkit/forms/validation.html" %}
-{% endwith %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -449,10 +449,9 @@ class TestCreateNewBrief(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         assert res.status_code == 400
-        anchor = document.cssselect('div.validation-masthead a[href="#title"]')
+        anchor = document.cssselect('div.govuk-error-summary a')
 
-        assert len(anchor) == 1
-        assert "Title" in anchor[0].text_content().strip()
+        assert len(anchor) == 1  # check that the framework iteration rendered a specific error message
         self.data_api_client.create_brief.assert_called_with(
             'digital-outcomes-and-specialists',
             'digital-specialists',


### PR DESCRIPTION
trello: https://trello.com/c/qUAR9Nm4/20-1-replace-validation-banner-with-govuk-frontend-error-summary-component-in-the-briefs-frontend