### PR TITLE
Remove document lists

### DIFF
--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -78,20 +78,13 @@
           %}
               {% include "toolkit/instruction-list.html" %}
           {% endwith %}
-
-          {%
-          with
-          items = [
-              {
-                  "title": "Download supplier responses to this requirement",
-                  "link": url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                  "file_type": "ODS",
-                  "download": "True"
-              }
-          ]
-          %}
-              {% include "toolkit/documents.html" %}
-          {% endwith %}
+          
+          <div class="govuk-width-full">
+            <a class="govuk-link" 
+                href="{{ url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}"
+                download
+            >Download supplier responses to this requirement (ODS)</a>
+          </div>
 
         {% else %}
           <div class="dmspeak">
@@ -105,19 +98,12 @@
             </p>
           </div>
 
-          {%
-          with
-          items = [
-              {
-                  "title": "Download supplier responses to \u2018" + brief.get('title', brief['lotName']) + "\u2019",
-                  "link": url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                  "file_type": "CSV",
-                  "download": "True"
-              }
-          ]
-          %}
-              {% include "toolkit/documents.html" %}
-          {% endwith %}
+          <div class="govuk-width-full">
+            <a class="govuk-link" 
+                href="{{ url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}"
+                download
+            >Download supplier responses to ‘{{ brief.get('title', brief['lotName']) }}’ (CSV)</a>
+          </div>
 
         {% endif %}
       {% else %}

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -77,19 +77,9 @@
         </div>
 
         <h2>Download the list of labs</h2>
-
-        {%
-        with
-            items = [
-            {
-            "title": "List of labs",
-            "link": "https://assets.digitalmarketplace.service.gov.uk/{}/communications/catalogues/user-research-studios.csv".format(framework.slug),
-            "file_type": "csv"
-            }
-            ]
-        %}
-        {% include "toolkit/documents.html" %}
-        {% endwith %}
+        <a class="govuk-link govuk-!-display-inline-block govuk-!-margin-top-2 govuk-!-margin-bottom-6" 
+            href="{{ 'https://assets.digitalmarketplace.service.gov.uk/{}/communications/catalogues/user-research-studios.csv'.format(framework.slug) }}"      
+        >List of labs (CSV)</a>
 
         <p class="govuk-body">Get help filtering the list at <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
 

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -2394,7 +2394,7 @@ class TestViewBriefResponsesPageForLegacyBrief(AbstractViewBriefResponsesPage):
 
         assert res.status_code == 200
         assert self._strip_whitespace(csv_link.text_content()) == \
-            "CSVdocument:Downloadsupplierresponsesto‘Ineedathingtodoathing’"
+            "Downloadsupplierresponsesto‘Ineedathingtodoathing’(CSV)"
 
 
 class TestViewBriefResponsesPageForNewFlowBrief(AbstractViewBriefResponsesPage):
@@ -2443,7 +2443,7 @@ class TestViewBriefResponsesPageForNewFlowBrief(AbstractViewBriefResponsesPage):
 
         assert res.status_code == 200
         assert self._strip_whitespace(csv_link.text_content()) == \
-            "ODSdocument:Downloadsupplierresponsestothisrequirement"
+            "Downloadsupplierresponsestothisrequirement(ODS)"
 
 
 class TestViewQuestionAndAnswerDates(BaseApplicationTest):

--- a/tests/main/views/test_digital_outcomes_and_specialists.py
+++ b/tests/main/views/test_digital_outcomes_and_specialists.py
@@ -140,7 +140,7 @@ class TestStartStudiosInfoPage(BaseApplicationTest):
 
         document = html.fromstring(res.get_data(as_text=True))
 
-        assert document.xpath("//a[@class='document-link-with-icon']")[0].attrib['href'] == (
+        assert document.xpath("//a[normalize-space(text())='List of labs (CSV)']")[0].attrib['href'] == (
             f"https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists{slug_suffix}"
             f"/communications/catalogues/user-research-studios.csv"
         )


### PR DESCRIPTION
https://trello.com/c/wDv13krp/44-2-remove-document-lists-from-briefs-frontend

There is one use of document list styles in the [analytics events JS](https://github.com/alphagov/digitalmarketplace-briefs-frontend/blob/d2cb903de5f81bfd936805d9fc54ee5603681349/app/assets/javascripts/analytics/_events.js#L40).

Rather than delete the unused analytics files here, I've submitted [another PR](https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/310).
