### PR TITLE
bump frameworks version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,8 +2075,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#8ab8e5c30b7304ed44612485b15b1a47f3702e49",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.9.0"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#85e44c94bdbe750795c9ef741bb6e4d14e48e545",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.0"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.9.0",
+    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.9.0",
     "govuk-elements-sass": "3.0.3",


### PR DESCRIPTION
part of https://trello.com/c/6b806g3r/40-remove-map-pdf-from-dos-brief-where-supplier-will-work