### PR TITLE
bump utils

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ Flask-Login==0.5.0
 Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.5.0#egg=digitalmarketplace-utils==51.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.5.0#egg=digitalmarketplace-utils==51.5.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2           # via digitalmarketplace-utils


### PR DESCRIPTION
part of https://trello.com/c/PTdD5lEh/102-our-logs-show-paas-instance-guid-but-not-paas-instance-index  
I don't think the breaking change should effect this app: https://github.com/alphagov/digitalmarketplace-utils/blob/master/CHANGELOG.md#5200﻿
