### PR TITLE
Use govukInput for buyer signup form

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -53,6 +53,7 @@ $govuk-global-styles: true;
 
 // Overrides
 @import "overrides/_notifications_banner";
+@import "overrides/_govuk-label";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_govuk-label.scss
+++ b/app/assets/scss/overrides/_govuk-label.scss
@@ -1,0 +1,15 @@
+// We want to ensure that govuk-label components are consistent with existing
+// labels. To do this we change the default label class to be styled like a
+// medium heading. This style was copied from
+// https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/label/_label.scss#L27-L30
+//
+// TODO: Remove/move this to digitalmarketplace-govuk-frontend when ready
+
+.govuk-label {
+  @include govuk-text-colour;
+  @include govuk-font($size: 24, $weight: bold);
+
+  display: block;
+
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -13,7 +13,7 @@
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader%}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter%}
 
-{% set assetPath = '/user/static' %}
+{% set assetPath = '/buyers/static' %}
 
 {% block head %}
   {% include "layouts/_site_verification.html" %}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -5,6 +5,7 @@
 {# Import GOV.UK Frontend components for globale usage#}
 {% from "govuk-frontend/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk-frontend/components/button/macro.njk" import govukButton %}
+{% from "govuk-frontend/components/input/macro.njk" import govukInput %}
 {% from "govuk-frontend/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk-frontend/components/phase-banner/macro.njk" import govukPhaseBanner %}
 

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -45,7 +45,20 @@
 
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-      {{ form.email_address }}
+      {{ govukInput({
+        "label": {
+          "text": form.email_address.label.text,
+        },
+        "errorMessage": errors.email_address.errorMessage,
+        "id": "input-email_address",
+        "name": "email_address",
+        "type": "email",
+        "value": form.email_address.data,
+        "attributes": {
+          "autocomplete": "username",
+          "spellcheck": "false",
+        }
+      }) }}
 
       {{ govukButton({
         "text": "Create account",

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -41,7 +41,7 @@
       We will send an account activation email to this address. You will then be able to set your password.
     </p>
 
-    <form method="POST" action="{{ url_for('.submit_create_buyer_account') }}">
+    <form method="POST" action="{{ url_for('.submit_create_buyer_account') }}" novalidate>
 
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 

--- a/requirements.in
+++ b/requirements.in
@@ -9,4 +9,4 @@ itsdangerous==1.1.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ fleep==1.0.1              # via digitalmarketplace-utils
 future==0.18.2            # via notifications-python-client
 gds-metrics==0.2.0        # via digitalmarketplace-utils
 govuk-country-register==0.5.0  # via digitalmarketplace-utils
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha  # via -r requirements.in
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha  # via -r requirements.in
 idna==2.9                 # via cryptography, requests
 inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf


### PR DESCRIPTION
https://trello.com/c/Ht0k2BEJ/31-1-replace-text-boxes-with-govuk-frontend-text-input-component-in-create-a-buyer-account-journey

The Create Buyer Account form is relatively simple, consisting of just one text input. This PR directly replaces the WTForm-generated widget (which uses the old FE toolkit template) with the `govukInput` macro, following the steps in the User Frontend (see commit messages).

- Bumps govuk-frontend-jinja to fix the `indent.njk` errors
- Use the correct static path for this app
- Add in `govuk-label` override style, based on the User FE equivalent
- Replace the form input, using autocomplete settings in line with User FE and attributes from the existing WTForm

Tested the validation banners locally - seems to work ok!

Functional tests are OK up until the usual local Notify failure for this journey.