### PR TITLE
[WIP] Move content from EmailForm class to template

### DIFF
--- a/app/create_buyer/forms/auth_forms.py
+++ b/app/create_buyer/forms/auth_forms.py
@@ -6,9 +6,9 @@ from dmutils.forms.validators import EmailValidator as ValidEmailAddress
 
 class EmailAddressForm(FlaskForm):
     email_address = DMStripWhitespaceStringField(
-        "Your email address",
+        "",
         validators=[
-            DataRequired(message="Enter an email address"),
-            ValidEmailAddress(message="Enter an email address in the correct format, like name@example.gov.uk"),
+            DataRequired(message="email_address_data_required"),
+            ValidEmailAddress(message="email_address_invalid_email_address"),
         ]
     )

--- a/app/templates/create_buyer/create_buyer_account.html
+++ b/app/templates/create_buyer/create_buyer_account.html
@@ -41,15 +41,20 @@
       We will send an account activation email to this address. You will then be able to set your password.
     </p>
 
+    {% set emailAddressErrorMessages = {
+      "email_address_data_required": "Enter an email address",
+      "email_address_invalid_email_address": "Enter an email address in the correct format, like name@example.gov.uk",
+    } %}
+
     <form method="POST" action="{{ url_for('.submit_create_buyer_account') }}" novalidate>
 
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
       {{ govukInput({
         "label": {
-          "text": form.email_address.label.text,
+          "text": "Your email address",
         },
-        "errorMessage": errors.email_address.errorMessage,
+        "errorMessage": emailAddressErrorMessages[email_address.errorMessage],
         "id": "input-email_address",
         "name": "email_address",
         "type": "email",


### PR DESCRIPTION
**Trello:** https://trello.com/c/N2q43lqd

**TODO:** error banner is defined on _base_page.html so this code doesn't work as is. An option would be to overwrite errors before including base_page.html

<img width="942" alt="Screenshot 2020-06-05 at 18 41 49" src="https://user-images.githubusercontent.com/464306/83906867-41bda980-a75c-11ea-8f29-1f62a5aa89e5.png">

Label works fine:

<img width="625" alt="Screenshot 2020-06-05 at 18 43 32" src="https://user-images.githubusercontent.com/464306/83907018-88130880-a75c-11ea-8483-83861e2490b5.png">
