### PR TITLE
Revert "Replace flash messages with dmAlert"

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -593,7 +593,7 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
         abort(404)
 
     data_api_client.delete_brief(brief_id, current_user.email_address)
-    flash(BRIEF_DELETED_MESSAGE.format(brief=brief), "success")
+    flash(BRIEF_DELETED_MESSAGE.format(brief=brief))
 
     return redirect(url_for(".buyer_dos_requirements"))
 
@@ -613,6 +613,6 @@ def withdraw_a_brief(framework_slug, lot_slug, brief_id):
         abort(404)
 
     data_api_client.withdraw_brief(brief_id, current_user.email_address)
-    flash(BRIEF_WITHDRAWN_MESSAGE.format(brief=brief), "success")
+    flash(BRIEF_WITHDRAWN_MESSAGE.format(brief=brief))
 
     return redirect(url_for(".buyer_dos_requirements"))

--- a/app/main/views/outcome.py
+++ b/app/main/views/outcome.py
@@ -44,7 +44,7 @@ def award_or_cancel_brief(framework_slug, lot_slug, brief_id):
     if already_awarded is False and form.validate_on_submit():
         answer = form.data.get('award_or_cancel_decision')
         if answer == 'back':
-            flash(BRIEF_UPDATED_MESSAGE.format(brief=brief), "success")
+            flash(BRIEF_UPDATED_MESSAGE.format(brief=brief))
             return redirect(url_for('.buyer_dos_requirements'))
         elif answer == 'yes':
             return redirect(
@@ -188,7 +188,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
                 )
             else:
                 abort(400, "Unrecognized status '{}'".format(new_status))
-            flash(BRIEF_UPDATED_MESSAGE.format(brief=brief), "success")
+            flash(BRIEF_UPDATED_MESSAGE.format(brief=brief))
             return redirect(
                 url_for('.view_brief_overview', framework_slug=framework_slug, lot_slug=lot_slug, brief_id=brief_id)
             )
@@ -253,7 +253,7 @@ def award_brief_details(framework_slug, lot_slug, brief_id, brief_response_id):
                 section=section
             ), 400
 
-        flash(BRIEF_UPDATED_MESSAGE.format(brief=brief), "success")
+        flash(BRIEF_UPDATED_MESSAGE.format(brief=brief))
 
         return redirect(url_for(".buyer_dos_requirements"))
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -12,7 +12,6 @@
 {# Import DM Components #}
 {% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader%}
-{% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter%}
 
 {% set assetPath = '/buyers/static' %}
@@ -48,20 +47,7 @@
 {% endblock %}
 
 {% block content %}
-  {% block flashMessages %}
-    {% with
-      messages = get_flashed_messages(with_categories=True),
-      titles = {"error": "There is a problem", "success": "Success"}
-    %}
-      {% for category, message in messages %}
-        {{ dmAlert({
-          "titleText": titles[category] or message,
-          "text": message if category in titles else None,
-          "type": category,
-        }) }}
-      {% endfor %}
-    {% endwith %}
-  {% endblock flashMessages %}
+  {% include "toolkit/flash_messages.html" %}
   {% block errorSummary %}
     {% if errors %}
       {{ govukErrorSummary({

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -1676,10 +1676,7 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
             assert res.status_code == 302
             assert self.data_api_client.delete_brief.called
             assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-            self.assert_flashes(
-                "Your requirements ‘I need a thing to do a thing’ were deleted",
-                expected_category="success"
-            )
+            self.assert_flashes("Your requirements ‘I need a thing to do a thing’ were deleted")
 
     def test_404_if_framework_is_not_live_or_expired(self):
         for framework_status in ['coming', 'open', 'pending', 'standstill']:
@@ -1766,10 +1763,7 @@ class TestWithdrawBriefSubmission(BaseApplicationTest):
         assert res.status_code == 302
         assert self.data_api_client.delete_brief.call_args_list == []
         assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-        self.assert_flashes(
-            "You’ve withdrawn your requirements for ‘I need a thing to do a thing’",
-            expected_category="success"
-        )
+        self.assert_flashes("You’ve withdrawn your requirements for ‘I need a thing to do a thing’")
 
     @pytest.mark.parametrize('framework_status', ['coming', 'open', 'pending', 'standstill'])
     def test_404_if_framework_is_not_live_or_expired(self, framework_status):

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -295,7 +295,7 @@ class TestAwardBriefDetails(BaseApplicationTest):
         )
         assert res.status_code == 302
         assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", expected_category="success")
+        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", "message")
 
     @mock.patch('app.main.views.outcome.is_brief_correct')
     def test_award_brief_details_raises_400_if_brief_not_correct(self, is_brief_correct):
@@ -599,7 +599,7 @@ class TestCancelBrief(BaseApplicationTest):
 
         assert res.status_code == 302
         assert expected_url in redirect_text
-        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", expected_category="success")
+        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", "message")
 
 
 class TestAwardOrCancelBrief(BaseApplicationTest):
@@ -713,7 +713,7 @@ class TestAwardOrCancelBrief(BaseApplicationTest):
         self.login_as_buyer()
         self.client.post(self.url.format(brief_id=self.brief['id']), data={'award_or_cancel_decision': 'back'})
 
-        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", expected_category="success")
+        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", "message")
 
     def test_random_post_data_triggers_invalid_choice(self):
         self.login_as_buyer()


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-briefs-frontend#316

I forgot to test this with functional tests :'(

We also have a lot of stuff backed up for release behind the error summary bug on briefs frontend, and changes to functional tests for summary lists for buyer frontend

Let's revert this for now, focus on getting the bug fixed and buyer frontend released