### PR TITLE
bump api client version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,5 +8,5 @@ itsdangerous==1.1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.4.0#egg=digitalmarketplace-utils==52.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.7.0#egg=digitalmarketplace-content-loader==7.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click==7.0                # via flask
 contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.7.0#egg=digitalmarketplace-content-loader==7.7.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.4.0#egg=digitalmarketplace-utils==52.4.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client


### PR DESCRIPTION
part of https://trello.com/c/CUik4BTJ/103-3-we-store-email-addresses-of-users-who-try-to-create-a-buyer-account-in-our-logs-in-plaintext

Bump apiclient to get changes from https://github.com/alphagov/digitalmarketplace-apiclient/pull/231﻿
