### PR TITLE
Replace instruction list with Task List

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -57,5 +57,5 @@ $govuk-global-styles: true;
 @import "overrides/_summary-list.scss";
 @import "overrides/_question-advice.scss";
 @import "overrides/_dmspeak.scss";
-
-
+@import "overrides/_task-list";
+@import "overrides/_tags";

--- a/app/assets/scss/overrides/_tags.scss
+++ b/app/assets/scss/overrides/_tags.scss
@@ -1,0 +1,21 @@
+/**
+ * Newer versions of the design system replace .govuk-tag--inactive with .govuk-tag--grey.
+ * In addition, there are other tag colours available.
+ *
+ * .govuk-tag--inactive is deprecated
+ *
+ * Other tag colours are used at least in the Task List pattern.
+ *
+ * TODO: When we update the Design System to 3.6.0+, we should remove these overrides
+ */
+
+.govuk-tag--grey,
+.govuk-tag--inactive {
+    color: govuk-shade(govuk-colour("grey-1"), 30);
+    background: govuk-tint(govuk-colour("grey-1"), 90);
+}
+
+.govuk-tag--blue {
+    color: govuk-shade(govuk-colour("blue"), 30);
+    background: govuk-tint(govuk-colour("blue"), 80);
+}

--- a/app/assets/scss/overrides/_task-list.scss
+++ b/app/assets/scss/overrides/_task-list.scss
@@ -1,0 +1,88 @@
+// TODO: Remove when task lists incorporated into digitalmarketplace-govuk-frontend
+
+.dm-task-list {
+    list-style-type: none;
+    padding-left: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    &__section {
+      @include govuk-responsive-margin(7, "bottom");
+
+      h2 {
+        display: table;
+        @include govuk-font($size:24, $weight: bold);
+        @include govuk-responsive-margin(4, "bottom");
+      }
+    }
+
+    &__section-number {
+        display: table-cell;
+
+        @include govuk-media-query($from: tablet) {
+            min-width: govuk-spacing(6);
+            padding-right: 0;
+        }
+    }
+
+    &__text {
+      @include govuk-font($size: 19);
+      padding-left: 0;
+      @include govuk-media-query($from: tablet) {
+        padding-left: govuk-spacing(6);
+      }
+    }
+
+    &__link {
+      display: inline-block;
+      @include govuk-font($size: 19);
+      padding-left: 0;
+      @include govuk-media-query($from: tablet) {
+        padding-left: govuk-spacing(6);
+      }
+    }
+
+    &__items {
+      @include govuk-font($size: 19);
+      list-style: none;
+      padding-left: 0;
+      @include govuk-media-query($from: tablet) {
+        padding-left: govuk-spacing(6);
+      }
+    }
+
+    &__item {
+      border-bottom: 1px solid $govuk-border-colour;
+      margin-bottom: 0 !important;
+      padding-top: govuk-spacing(2);
+      padding-bottom: govuk-spacing(2);
+      @include govuk-clearfix;
+    }
+
+    &__item:first-child {
+      border-top: 1px solid $govuk-border-colour;
+    }
+
+    &__task-name {
+      display: block;
+      @include govuk-media-query($from: 450px) {
+        float: left;
+      }
+    }
+
+    &__tag {
+      margin-top: govuk-spacing(2);
+      margin-bottom: govuk-spacing(1);
+    
+      @include govuk-media-query($from: 450px) {
+        float: right;
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+      /**
+       * We want to override the govuk tag behaviour of capitalising text.
+       * This rule should be kept when we upgrade to v3.
+       */
+      text-transform: none;
+    }
+}

--- a/app/main/views/requirement_task_list.py
+++ b/app/main/views/requirement_task_list.py
@@ -64,7 +64,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
         for index, question in enumerate(brief['clarificationQuestions'])
     ]
 
-    publish_requirements_section_links = [
+    publish_requirements_section_instructions = [
         {
             'href': url_for(
                 ".preview_brief",
@@ -75,7 +75,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
             'text': 'Preview your requirements',
             'allowed_statuses': ['draft'],
             'startable': sections_status['previewable'],
-            'id': 'preview_brief_link'
+            'active_tag': 'Optional'
         },
         {
             'href': url_for(
@@ -87,8 +87,10 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
             'text': 'Publish your requirements',
             'allowed_statuses': ['draft'],
             'startable': sections_status['publishable'],
-            'id': 'publish_brief_link'
+            'active_tag': 'To do'
         },
+    ]
+    publish_requirements_section_links = [
         {
             'href': url_for(
                 ".view_brief_timeline",
@@ -121,5 +123,6 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
         call_off_contract_url=call_off_contract_url,
         framework_agreement_url=framework_agreement_url,
         awarded_brief_response_supplier_name=awarded_brief_response_supplier_name,
-        publish_requirements_section_links=publish_requirements_section_links
+        publish_requirements_section_links=publish_requirements_section_links,
+        publish_requirements_section_instructions=publish_requirements_section_instructions
     ), 200

--- a/app/main/views/requirement_task_list.py
+++ b/app/main/views/requirement_task_list.py
@@ -9,7 +9,6 @@ from ..helpers.buyers_helpers import (
     count_unanswered_questions,
     get_framework_and_lot,
     is_brief_correct,
-    section_has_at_least_one_required_question,
 )
 
 
@@ -39,13 +38,26 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
     call_off_contract_url = content_loader.get_message(brief['frameworkSlug'], 'urls', 'call_off_contract_url')
     framework_agreement_url = content_loader.get_message(brief['frameworkSlug'], 'urls', 'framework_agreement_url')
 
-    completed_sections = {}
+    sections_status = {
+        'previewable': True,
+        'publishable': True
+    }
     for section in sections:
         required, optional = count_unanswered_questions([section])
-        if section_has_at_least_one_required_question(section):
-            completed_sections[section.slug] = True if required == 0 else False
-        else:
-            completed_sections[section.slug] = True if optional == 0 else False
+        if section.is_empty:
+            if required > 0:
+                sections_status[section.slug] = 'to_do'
+                sections_status['previewable'] = False
+                sections_status['publishable'] = False
+            elif optional > 0:
+                sections_status[section.slug] = 'optional'
+        elif not section.is_empty:
+            if required > 0:
+                sections_status[section.slug] = 'in_progress'
+                sections_status['previewable'] = False
+                sections_status['publishable'] = False
+            else:
+                sections_status[section.slug] = 'done'
 
     brief['clarificationQuestions'] = [
         dict(question, number=index + 1)
@@ -61,7 +73,9 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
                 brief_id=brief['id']
             ),
             'text': 'Preview your requirements',
-            'allowed_statuses': ['draft']
+            'allowed_statuses': ['draft'],
+            'startable': sections_status['previewable'],
+            'id': 'preview_brief_link'
         },
         {
             'href': url_for(
@@ -71,7 +85,9 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
                 brief_id=brief['id']
             ),
             'text': 'Publish your requirements',
-            'allowed_statuses': ['draft']
+            'allowed_statuses': ['draft'],
+            'startable': sections_status['publishable'],
+            'id': 'publish_brief_link'
         },
         {
             'href': url_for(
@@ -100,7 +116,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
         confirm_remove=request.args.get("confirm_remove", None),
         brief=section.unformat_data(brief),
         sections=sections,
-        completed_sections=completed_sections,
+        sections_status=sections_status,
         step_sections=[section.step for section in sections if hasattr(section, 'step')],
         call_off_contract_url=call_off_contract_url,
         framework_agreement_url=framework_agreement_url,

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -157,15 +157,6 @@
                 'text': 'Awarded to ' + awarded_brief_response_supplier_name,
                 'allowed_statuses': ['awarded']
               },
-              'additional_instructions': [
-                {
-                  'href': url_for(".award_or_cancel_brief", framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                  'text': "Let suppliers know the outcome",
-                  'allowed_statuses': ['closed'],
-                  'startable': true,
-                  'active_tag': 'To do'
-                }
-              ],
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services',
@@ -176,6 +167,11 @@
                   'href': call_off_contract_url,
                   'text': "Download the " + brief.framework.name + " contract",
                   'allowed_statuses': ['draft', 'live', 'closed']
+                },
+                {
+                  'href': url_for(".award_or_cancel_brief", framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  'text': "Let suppliers know the outcome",
+                  'allowed_statuses': ['closed']
                 }
               ]
             }

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -37,8 +37,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% block before_sections %}{% endblock %}
-      <ol class="instruction-list steps">
-
         {% with
           steps = [
             {
@@ -73,6 +71,7 @@
                 'cancelled': 'Done',
                 'unsuccessful': 'Done',
               },
+              'additional_instructions': publish_requirements_section_instructions,
               'links': publish_requirements_section_links
             },
             {
@@ -158,6 +157,15 @@
                 'text': 'Awarded to ' + awarded_brief_response_supplier_name,
                 'allowed_statuses': ['awarded']
               },
+              'additional_instructions': [
+                {
+                  'href': url_for(".award_or_cancel_brief", framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  'text': "Let suppliers know the outcome",
+                  'allowed_statuses': ['closed'],
+                  'startable': true,
+                  'active_tag': 'To do'
+                }
+              ],
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services',
@@ -168,62 +176,88 @@
                   'href': call_off_contract_url,
                   'text': "Download the " + brief.framework.name + " contract",
                   'allowed_statuses': ['draft', 'live', 'closed']
-                },
-                {
-                  'href': url_for(".award_or_cancel_brief", framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                  'text': "Let suppliers know the outcome",
-                  'allowed_statuses': ['closed']
                 }
               ]
             }
           ]
         %}
 
-        {% for step in steps %}
+        <ol class="dm-task-list">
+          {% for step in steps %}
           {% set step_number = loop.index %}
-          <li class="instruction-list-item divider">
-            <h2 class="instruction-list-item-body">
-              <span class="step-number" role="presentation">{{ step_number }}. </span>
-              {{ step.title }}</h2>
-            {% if step.description %}
-              <p class="instruction-list-item-top">{{ step.description[brief.status] }}</p>
+          <li class="dm-task-list__section">
+            <h2><span class="dm-task-list__section-number">{{ step_number }}. </span>{{ step.title }}</h2>
+            <!-- Description -->
+            {% if step.description[brief.status]|length %}
+            <p class="dm-task-list__text">{{ step.description[brief.status] }}</p>
             {% endif %}
-            {% if step.body %}
-              {% if not step.body.allowed_statuses or brief.status in step.body.allowed_statuses %}
-                <p class="instruction-list-item-top">{{ step.body.text }}</p>
-              {% endif %}
-            {% endif %}
-            {% if step_number in step_sections and brief.status == 'draft' %}
-                <ul class="instruction-list-item-top">
-                  {% for section in sections %}
-                    {% if section.step == step_number %}
-                    <li>
-                      {% if completed_sections[section.slug]  %}
-                        <span class="tick">
-                          <img src="{{ asset_path }}svg/tick.svg" alt="done" width="15" height="14" />
-                        </span>
-                      {% endif %}
-                      <a class="govuk-link" href="{{ brief_links.brief_link_url('grandparent', section, brief) }}">{{ section.name }}</a>
-                    </li>
-                    {% endif %}
-                  {% endfor %}
-                </ul>
-            {% endif %}
+            <!-- Non-task list links -->
             {% if step.links %}
-              <ul class="instruction-list-item-top">
-                {% for link in step.links %}
-                  {% if not link.allowed_statuses or brief.status in link.allowed_statuses %}
-                    <li>
-                      <a class="govuk-link" href="{{ link.href }}">{{ link.text }}</a>
-                    </li>
-                  {% endif %}
-                {% endfor %}
+              <ul class="govuk-list">
+              {% for link in step.links %}
+                {% if brief.status in link.allowed_statuses %}
+                  <li><a class="govuk-link dm-task-list__link" href="{{ link.href }}">{{ link.text }}</a></li>
+                {% endif %}
+              {% endfor %}
               </ul>
             {% endif %}
+            <!-- Body -->
+            {% if step.body %}
+              {% if not step.body.allowed_statuses or brief.status in step.body.allowed_statuses %}
+                <p class="dm-task-list__text">{{ step.body.text }}</p>
+              {% endif %}
+            {% endif %}
+            <!-- Instructions -->
+            <ul class="dm-task-list__items">
+              {% if step_number in step_sections and brief.status == 'draft' %}
+                {% for section in sections %}
+                  {% if section.step == step_number %}
+                  <li class="dm-task-list__item">
+                    <span class="dm-task-list__task-name">
+                      <a class="govuk-link"
+                        href="{{ brief_links.brief_link_url('grandparent', section, brief) }}"
+                        aria-describedby="step-{{ step_number }}-{{ section.id }}"
+                      >{{ section.name }}</a>
+                    </span>
+                    {% if sections_status[section.slug] == "done" %}
+                    <strong class="govuk-tag dm-task-list__tag" id="step-{{ step_number }}-{{ section.id }}">Done</strong>
+                    {% elif sections_status[section.slug] == 'to_do' %}
+                    <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-{{ step_number }}-{{ section.id }}">To do</strong>
+                    {% elif sections_status[section.slug] == 'optional' %}
+                    <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-{{ step_number }}-{{ section.id }}">Optional</strong>
+                    {% elif sections_status[section.slug] == 'in_progress' %}
+                    <strong class="govuk-tag govuk-tag--blue dm-task-list__tag" id="step-{{ step_number }}-{{ section.id }}">In progress</strong>
+                    {% endif %}
+                  </li>
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+              {% for instruction in step.additional_instructions %}
+                {% if brief.status in instruction.allowed_statuses %}
+                  {% if instruction.startable == true %}
+                  <li class="dm-task-list__item">
+                    <span class="dm-task-list__task-name">
+                      <a class="govuk-link" 
+                        href="{{ instruction.href }}"
+                        aria-describedby="step-{{ step_number }}-link-{{loop.index}}"
+                      >{{ instruction.text }}</a>
+                    </span>
+                    <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-{{ step_number }}-instruction-{{ loop.index }}">{{ instruction.active_tag }}</strong>
+                  </li>
+                  {% else %}
+                  <li class="dm-task-list__item">
+                    <span class="dm-task-list__task-name">{{ instruction.text }}</span>
+                    <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-{{ step_number }}-instruction-{{ loop.index }}">Cannot start yet</strong>
+                  </li>
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+            </ul>
           </li>
-        {% endfor %}
+          {% endfor %}
+        </ol>
+
         {% endwith %}
-      </ol>
     </div>
     <div class="govuk-grid-column-one-third">
       {% if brief.status == 'closed' %}

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,6 +12,7 @@ mock
 pytest
 pytest-cov
 python-dotenv  # used to load .flaskenv
+syrupy
 watchdog
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.7.0#egg=digitalmarketplace-test-utils==2.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,10 +4,11 @@
 #
 #    pip-compile requirements-dev.in
 #
-attrs==19.3.0             # via pytest
+attrs==19.3.0             # via pytest, syrupy
 certifi==2019.11.28       # via -c requirements.txt, requests
 chardet==3.0.4            # via -c requirements.txt, requests
 click==7.0                # via -c requirements.txt, pip-tools
+colored==1.4.2            # via syrupy
 coverage==5.0.3           # via -r requirements-dev.in, coveralls, pytest-cov
 coveralls==1.11.1         # via -r requirements-dev.in
 cssselect==1.1.0          # via -r requirements-dev.in
@@ -31,11 +32,13 @@ pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements-dev.in
-pytest==5.3.5             # via -r requirements-dev.in, pytest-cov
+pytest==5.3.5             # via -r requirements-dev.in, pytest-cov, syrupy
 python-dateutil==2.8.1    # via -c requirements.txt, freezegun
 python-dotenv==0.11.0     # via -r requirements-dev.in
 requests==2.23.0          # via -c requirements.txt, coveralls
 six==1.14.0               # via -c requirements.txt, freezegun, packaging, pip-tools, python-dateutil
+syrupy==0.6.1             # via -r requirements-dev.in
+typing-extensions==3.7.4.2  # via syrupy
 urllib3==1.25.8           # via -c requirements.txt, requests
 watchdog==0.10.2          # via -r requirements-dev.in
 wcwidth==0.1.8            # via pytest

--- a/tests/main/views/__snapshots__/test_requirement_task_list.ambr
+++ b/tests/main/views/__snapshots__/test_requirement_task_list.ambr
@@ -1,0 +1,2241 @@
+# name: TestRequirementsTaskListPageAwardedBrief.test_awarded_brief_requirements_task_list[expired]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/responses">View suppliers who applied</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+                  <p class="dm-task-list__text">Awarded to 100 Percent IT Ltd</p>
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageAwardedBrief.test_awarded_brief_requirements_task_list[live]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/responses">View suppliers who applied</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+                  <p class="dm-task-list__text">Awarded to 100 Percent IT Ltd</p>
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageCancelledOrUnsuccessfulBrief.test_cancelled_or_unsuccessful_brief_requirements_task_list[cancelled-expired]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/responses">View suppliers who applied</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">The contract was not awarded - the requirements were cancelled.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageCancelledOrUnsuccessfulBrief.test_cancelled_or_unsuccessful_brief_requirements_task_list[cancelled-live]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/responses">View suppliers who applied</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">The contract was not awarded - the requirements were cancelled.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageCancelledOrUnsuccessfulBrief.test_cancelled_or_unsuccessful_brief_requirements_task_list[unsuccessful-expired]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/responses">View suppliers who applied</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">The contract was not awarded - no suitable suppliers applied.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageCancelledOrUnsuccessfulBrief.test_cancelled_or_unsuccessful_brief_requirements_task_list[unsuccessful-live]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/responses">View suppliers who applied</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">The contract was not awarded - no suitable suppliers applied.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageClosedBrief.test_closed_brief_requirements_task_list[expired]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/responses">View and shortlist suppliers</a></li>
+                  
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">How to shortlist suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Evaluate your shortlist using the criteria and methods you published with your requirements.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers">How to evaluate suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">You must give your chosen supplier a contract before they start work.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services">How to award a contract</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/government/publications/digital-outcomes-and-specialists-4-call-off-contract">Download the Digital Outcomes and Specialists 4 contract</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/award">Let suppliers know the outcome</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageClosedBrief.test_closed_brief_requirements_task_list[live]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/responses">View and shortlist suppliers</a></li>
+                  
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">How to shortlist suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Evaluate your shortlist using the criteria and methods you published with your requirements.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers">How to evaluate suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">You must give your chosen supplier a contract before they start work.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services">How to award a contract</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/government/publications/digital-outcomes-and-specialists-4-call-off-contract">Download the Digital Outcomes and Specialists 4 contract</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/award">Let suppliers know the outcome</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageDraftBrief.test_draft_brief_requirements_task_list
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Before you can publish your requirements, you must complete:</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">
+                        <a class="govuk-link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/edit/title/title%0A%20%20%20%20%0A%20%20%0A" aria-describedby="step-1-title">Title</a>
+                      </span>
+                      
+                      <strong class="govuk-tag dm-task-list__tag" id="step-1-title">Done</strong>
+                      
+                    </li>
+                    
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">
+                        <a class="govuk-link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/edit/specialist-role/specialistRole%0A%20%20%20%20%0A%20%20%0A" aria-describedby="step-1-specialist-role">Specialist role</a>
+                      </span>
+                      
+                      <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-1-specialist-role">To do</strong>
+                      
+                    </li>
+                    
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">
+                        <a class="govuk-link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/edit/location/location%0A%20%20%20%20%0A%20%20%0A" aria-describedby="step-1-location">Location</a>
+                      </span>
+                      
+                      <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-1-location">To do</strong>
+                      
+                    </li>
+                    
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">
+                        <a class="govuk-link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/description-of-work%0A%20%20%0A" aria-describedby="step-1-description-of-work">Description of work</a>
+                      </span>
+                      
+                      <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-1-description-of-work">To do</strong>
+                      
+                    </li>
+                    
+                  
+                    
+                  
+                    
+                  
+                    
+                  
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Before you can publish your requirements, you must complete:</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                  
+                    
+                  
+                    
+                  
+                    
+                  
+                    
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">
+                        <a class="govuk-link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/shortlist-and-evaluation-process%0A%20%20%0A" aria-describedby="step-2-shortlist-and-evaluation-process">Shortlist and evaluation process</a>
+                      </span>
+                      
+                      <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-2-shortlist-and-evaluation-process">To do</strong>
+                      
+                    </li>
+                    
+                  
+                    
+                  
+                    
+                  
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                  
+                    
+                  
+                    
+                  
+                    
+                  
+                    
+                  
+                    
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">
+                        <a class="govuk-link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/edit/set-how-long-your-requirements-will-be-open-for/requirementsLength%0A%20%20%20%20%0A%20%20%0A" aria-describedby="step-3-set-how-long-your-requirements-will-be-open-for">Set how long your requirements will be open for</a>
+                      </span>
+                      
+                      <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-3-set-how-long-your-requirements-will-be-open-for">To do</strong>
+                      
+                    </li>
+                    
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">
+                        <a class="govuk-link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/describe-question-and-answer-session%0A%20%20%0A" aria-describedby="step-3-describe-question-and-answer-session">Describe question and answer session</a>
+                      </span>
+                      
+                      <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-3-describe-question-and-answer-session">Optional</strong>
+                      
+                    </li>
+                    
+                  
+                
+                
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">Preview your requirements</span>
+                      <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-3-instruction-1">Cannot start yet</strong>
+                    </li>
+                    
+                  
+                
+                  
+                    
+                    <li class="dm-task-list__item">
+                      <span class="dm-task-list__task-name">Publish your requirements</span>
+                      <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="step-3-instruction-2">Cannot start yet</strong>
+                    </li>
+                    
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">When you&#8217;ve published your requirements, you must answer all supplier questions.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements">How to answer supplier questions</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">After the application deadline, shortlist the suppliers who applied.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">How to shortlist suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Evaluate your shortlist using the criteria and methods you published with your requirements.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers">How to evaluate suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">You must give your chosen supplier a contract before they start work.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services">How to award a contract</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/government/publications/digital-outcomes-and-specialists-4-call-off-contract">Download the Digital Outcomes and Specialists 4 contract</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageLiveBrief.test_live_brief_requirements_task_list[expired]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Open for applications until Thursday 7 April 2016 at 12:00am GMT.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/timeline">View question and answer dates</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">You must answer all questions by Saturday 2 April 2016. Suppliers will send you questions by email.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/supplier-questions">Publish questions and answers</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements">How to answer supplier questions</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">After the application deadline, shortlist the suppliers who applied.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">How to shortlist suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Evaluate your shortlist using the criteria and methods you published with your requirements.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers">How to evaluate suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">You must give your chosen supplier a contract before they start work.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services">How to award a contract</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/government/publications/digital-outcomes-and-specialists-4-call-off-contract">Download the Digital Outcomes and Specialists 4 contract</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---
+# name: TestRequirementsTaskListPageLiveBrief.test_live_brief_requirements_task_list[live]
+  '
+  <ol class="dm-task-list">
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">1. </span>Write requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">2. </span>Set how you&#8217;ll evaluate suppliers</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Done</p>
+              
+              <!-- Non-task list links -->
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">3. </span>Publish requirements</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Open for applications until Thursday 7 April 2016 at 12:00am GMT.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/timeline">View question and answer dates</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/digital-outcomes-and-specialists/opportunities/1234">View your published requirements</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+                  
+                
+                  
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">4. </span>Answer supplier questions</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">You must answer all questions by Saturday 2 April 2016. Suppliers will send you questions by email.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/supplier-questions">Publish questions and answers</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements">How to answer supplier questions</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">5. </span>Shortlist</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">After the application deadline, shortlist the suppliers who applied.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">How to shortlist suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">6. </span>Evaluate</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">Evaluate your shortlist using the criteria and methods you published with your requirements.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers">How to evaluate suppliers</a></li>
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+            
+            <li class="dm-task-list__section">
+              <h2><span class="dm-task-list__section-number">7. </span>Award a contract</h2>
+              <!-- Description -->
+              
+              <p class="dm-task-list__text">You must give your chosen supplier a contract before they start work.</p>
+              
+              <!-- Non-task list links -->
+              
+                <ul class="govuk-list">
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services">How to award a contract</a></li>
+                  
+                
+                  
+                    <li><a class="govuk-link dm-task-list__link" href="https://www.gov.uk/government/publications/digital-outcomes-and-specialists-4-call-off-contract">Download the Digital Outcomes and Specialists 4 contract</a></li>
+                  
+                
+                  
+                
+                </ul>
+              
+              <!-- Body -->
+              
+                
+              
+              <!-- Instructions -->
+              <ul class="dm-task-list__items">
+                
+                
+              </ul>
+            </li>
+            
+          </ol>
+  
+          
+      
+  '
+---

--- a/tests/main/views/test_requirement_task_list.py
+++ b/tests/main/views/test_requirement_task_list.py
@@ -8,389 +8,496 @@ from dmtestutils.api_model_stubs import BriefStub, FrameworkStub, LotStub
 from ...helpers import BaseApplicationTest
 
 
-class TestBriefSummaryPage(BaseApplicationTest):
+class BaseRequirementsTaskListPageTest:
+    """Common tests for the create a brief journey's task list page
 
-    SIDE_LINKS_XPATH = '//div[@class="govuk-grid-column-one-third"]//a'
-    INSTRUCTION_LINKS_XPATH = '//span[@class="dm-task-list__task-name"]/a'
-    INSTRUCTION_TAGS_XPATH = '//main//ol/li/ul/li//strong'
-    GUIDANCE_LINKS_XPATH = '//a[@class="govuk-link dm-task-list__link"]'
-    INSTRUCTION_TEXT_XPATH = '//main//ol/li/ul/li/span[not(./a)]'
+    Tests of things that should stay the same in all states.
+    """
+
+    task_list_selector = "ol.dm-task-list"
+    task_list_section_selector = f"{task_list_selector} li.dm-task-list__section"
+    task_list_item_selector = f"{task_list_section_selector} ul.dm-task-list__items > li.dm-task-list__item"
+    task_list_tags_selector = f"{task_list_item_selector} strong.govuk-tag.dm-task-list__tag"
+    task_list_link_selector = f"{task_list_section_selector} ul.govuk-list > li.dm-task-list__link"
 
     def setup_method(self, method):
         super().setup_method(method)
-        self.data_api_client_patch = mock.patch('app.main.views.requirement_task_list.data_api_client', autospec=True)
+        self.data_api_client_patch = mock.patch("app.main.views.requirement_task_list.data_api_client", autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
 
-        self.data_api_client.get_brief.return_value = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-        ).single_result_response()
-        self.data_api_client.get_framework.return_value = FrameworkStub(
-            slug='digital-outcomes-and-specialists-4',
-            status='live',
-            lots=[
-                LotStub(slug='digital-specialists', allows_brief=True).response()
-            ]
-        ).single_result_response()
         self.login_as_buyer()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
-    @staticmethod
-    def _get_links(document, xpath, text_only=None):
-        if text_only:
-            return [e.text_content() for e in document.xpath(xpath)]
-        return [
-            (e.text_content(), e.get('href')) for e in document.xpath(xpath)
+    def get_requirements_task_list_page(self, brief: dict) -> html.HtmlElement:
+        url = f"/buyers/frameworks/{brief['framework']['slug']}/requirements/{brief['lotSlug']}/{brief['id']}"
+        res = self.client.get(url)
+
+        assert res.status_code == 200, f"Cannot access requirements task list page for {brief['status']} brief at {url}"
+
+        return html.fromstring(res.get_data(as_text=True))
+
+    @pytest.fixture
+    def requirements_task_list_page(self, brief) -> html.HtmlElement:
+        return self.get_requirements_task_list_page(brief)
+
+    @pytest.fixture
+    def task_list_html(self, requirements_task_list_page) -> str:
+        task_list = requirements_task_list_page.cssselect(self.task_list_selector)
+        assert len(task_list) == 1
+        return html.tostring(task_list[0]).decode()
+
+    def test_can_view_requirements_task_list_page(self, brief):
+        assert self.get_requirements_task_list_page(brief)
+
+    def test_requirements_task_list_page_title_starts_with_brief_title(self, brief, requirements_task_list_page):
+        page_title = requirements_task_list_page.find("head/title").text.strip()
+        assert page_title.startswith(brief["title"])
+
+    def test_requirements_task_list_page_heading_is_brief_title(self, brief, requirements_task_list_page):
+        page_heading = requirements_task_list_page.cssselect("h1")[0].text_content()
+        assert page_heading.strip() == brief["title"]
+
+    def test_requirements_task_list_page_has_task_list(self, requirements_task_list_page):
+        assert requirements_task_list_page.cssselect(self.task_list_selector)
+
+    def test_task_list_has_sections(self, requirements_task_list_page):
+        sections = requirements_task_list_page.cssselect(self.task_list_section_selector)
+        headings = [section.cssselect("h2")[0] for section in sections]
+
+        assert [h2.text_content().strip() for h2 in headings] == [
+            "1. Write requirements",
+            "2. Set how you’ll evaluate suppliers",
+            "3. Publish requirements",
+            "4. Answer supplier questions",
+            "5. Shortlist",
+            "6. Evaluate",
+            "7. Award a contract",
         ]
 
-    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
-    def test_show_draft_brief_summary_page(self, framework_status):
+    def test_task_list_items_have_tags(self, requirements_task_list_page):
+        """Test that each item has a tag with allowed text"""
+        tags = requirements_task_list_page.cssselect(self.task_list_tags_selector)
+
+        allowed_tags = ("Done", "To do", "In progress", "Optional", "Cannot start yet")
+
+        for tag in tags:
+            assert tag.text in allowed_tags
+
+
+class TestRequirementsTaskListPageDraftBrief(BaseRequirementsTaskListPageTest, BaseApplicationTest):
+    """Test the requirements task list page when a brief is being drafted
+
+    This should only possible with a live framework
+    """
+
+    @pytest.fixture(autouse=True)
+    def brief(self):
+        """A draft brief on a live framework"""
         self.data_api_client.get_framework.return_value = FrameworkStub(
-            slug='digital-outcomes-and-specialists-4',
-            status=framework_status,
-            lots=[
-                LotStub(slug='digital-specialists', allows_brief=True).response(),
-            ]
-        ).single_result_response()
-        brief_json = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-            status="draft",
-        ).single_result_response()
-        brief_json['briefs']['specialistRole'] = 'communicationsManager'
-        self.data_api_client.get_brief.return_value = brief_json
-
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"
-        )
-
-        assert res.status_code == 200
-        page_html = res.get_data(as_text=True)
-        document = html.fromstring(page_html)
-
-        assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-        assert self._get_links(document, self.GUIDANCE_LINKS_XPATH, text_only=True) == [
-            'How to answer supplier questions',
-            'How to shortlist suppliers',
-            'How to evaluate suppliers',
-            'How to award a contract',
-            'Download the Digital Outcomes and Specialists 4 contract',
-        ]
-        assert self._get_links(document, self.INSTRUCTION_LINKS_XPATH, text_only=True) == [
-            'Title',
-            'Specialist role',
-            'Location',
-            'Description of work',
-            'Shortlist and evaluation process',
-            'Set how long your requirements will be open for',
-            'Describe question and answer session',
-        ]
-        assert self._get_links(document, self.INSTRUCTION_TEXT_XPATH, text_only=True) == [
-            'Preview your requirements',
-            'Publish your requirements',
-        ]
-
-        assert self._get_links(document, self.INSTRUCTION_TAGS_XPATH, text_only=True) == [
-            'Done',             # Title
-            'Done',             # Specialist role
-            'To do',            # Location
-            'To do',            # Description of work
-            'To do',            # Shortlist and evaluation process
-            'To do',            # Set how long your requirements will be open for
-            'Optional',         # Describe question and answer session
-            'Cannot start yet',  # Preview your requirements
-            'Cannot start yet',  # Publish your requirements
-        ]
-
-        assert "Awarded to " not in page_html
-        assert self._get_links(document, self.SIDE_LINKS_XPATH) == [
-            (
-                "Delete draft requirements",
-                "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/delete"  # noqa
-            )
-        ]
-
-    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
-    def test_draft_brief_summary_page_tags_change_state(self, framework_status):
-        self.data_api_client.get_framework.return_value = FrameworkStub(
-            slug='digital-outcomes-and-specialists-4',
-            status=framework_status,
-            lots=[
-                LotStub(slug='digital-specialists', allows_brief=True).response(),
-            ]
-        ).single_result_response()
-        brief_json = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-            status="draft",
-        ).single_result_response()
-        # brief_json['briefs']['specialistRole'] = 'communicationsManager'
-        self.data_api_client.get_brief.return_value = brief_json
-
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"
-        )
-
-        assert res.status_code == 200
-        page_html = res.get_data(as_text=True)
-        document = html.fromstring(page_html)
-
-        initial_tags = self._get_links(document, self.INSTRUCTION_TAGS_XPATH, text_only=True)
-
-        assert initial_tags[1] == 'To do'   # Specialist role
-        assert initial_tags[3] == 'To do'   # Description of work
-
-        brief_json['briefs']['specialistRole'] = 'communicationsManager'
-        brief_json['briefs']['organisation'] = 'United Team Group'
-
-        self.data_api_client.get_brief.return_value = brief_json
-
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"
-        )
-
-        assert res.status_code == 200
-        page_html = res.get_data(as_text=True)
-        document = html.fromstring(page_html)
-
-        new_tags = self._get_links(document, self.INSTRUCTION_TAGS_XPATH, text_only=True)
-
-        assert new_tags[1] == 'Done'
-        assert new_tags[3] == 'In progress'
-
-    @pytest.mark.parametrize(
-        'status, banner_displayed',
-        [
-            ('draft', True),
-            ('live', False), ('closed', False), ('awarded', False), ('cancelled', False), ('unsuccessful', False)
-        ]
-    )
-    def test_brief_summary_with_delete_requested_displays_confirmation_banner_for_draft_briefs_only(
-            self, status, banner_displayed
-    ):
-        self.data_api_client.get_brief.return_value = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-            status=status,
-        ).single_result_response()
-
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"  # noqa
-        )
-
-        assert res.status_code == 200
-
-    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
-    def test_show_live_brief_summary_page_for_live_and_expired_framework(self, framework_status):
-        self.data_api_client.get_framework.return_value = FrameworkStub(
-            slug='digital-outcomes-and-specialists-4',
-            status=framework_status,
-            lots=[
-                LotStub(slug='digital-specialists', allows_brief=True).response(),
-            ]
-        ).single_result_response()
-        brief_json = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
+            slug="digital-outcomes-and-specialists-4",
             status="live",
+            lots=[LotStub(slug="digital-specialists", allows_brief=True).response()],
         ).single_result_response()
-        brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-        brief_json['briefs']['specialistRole'] = 'communicationsManager'
-        brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-        self.data_api_client.get_brief.return_value = brief_json
 
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"
-        )
-
-        assert res.status_code == 200
-        page_html = res.get_data(as_text=True)
-        document = html.fromstring(page_html)
-
-        assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-        assert self._get_links(document, self.GUIDANCE_LINKS_XPATH, text_only=True) == [
-            'View question and answer dates',
-            'View your published requirements',
-            'Publish questions and answers',
-            'How to answer supplier questions',
-            'How to shortlist suppliers',
-            'How to evaluate suppliers',
-            'How to award a contract',
-            'Download the Digital Outcomes and Specialists 4 contract',
-        ]
-
-        assert "Awarded to " not in page_html
-        assert self._get_links(document, self.SIDE_LINKS_XPATH) == [
-            (
-                'Withdraw requirements',
-                "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/withdraw"  # noqa
-            )
-        ]
-
-    @pytest.mark.parametrize(
-        'status, banner_displayed',
-        [
-            ('live', True),
-            ('draft', False), ('closed', False), ('awarded', False), ('cancelled', False), ('unsuccessful', False)
-        ]
-    )
-    def test_brief_summary_with_withdraw_requested_displays_confirmation_banner_for_live_briefs_only(
-            self, status, banner_displayed
-    ):
         self.data_api_client.get_brief.return_value = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-            status=status,
+            framework_slug="digital-outcomes-and-specialists-4", status="draft",
         ).single_result_response()
 
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234?withdraw_requested=True"  # noqa
+        return self.data_api_client.get_brief.return_value["briefs"]
+
+    def test_draft_brief_requirements_task_list(self, task_list_html, snapshot):
+        assert task_list_html == snapshot
+
+    def test_draft_brief_requirements_task_list_page_has_link_to_delete(self, brief, requirements_task_list_page):
+        sidebar = requirements_task_list_page.cssselect("div.govuk-grid-column-one-third")[0]
+        sidebar_links = sidebar.cssselect("a.govuk-link")
+        assert len(sidebar_links) == 1
+
+        delete_link = sidebar_links[0]
+        assert delete_link.text == "Delete draft requirements"
+        assert delete_link.attrib["href"] == (
+            f"/buyers/frameworks/{brief['framework']['slug']}" f"/requirements/{brief['lotSlug']}/{brief['id']}/delete"
         )
 
-        assert res.status_code == 200
-
-    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
-    def test_show_closed_brief_summary_page_for_live_and_expired_framework(self, framework_status):
-        self.data_api_client.get_framework.return_value = FrameworkStub(
-            slug='digital-outcomes-and-specialists-4',
-            status=framework_status,
-            lots=[
-                LotStub(slug='digital-specialists', allows_brief=True).response(),
-            ]
-        ).single_result_response()
-        brief_json = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-            status="closed",
-        ).single_result_response()
-        brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-        brief_json['briefs']['specialistRole'] = 'communicationsManager'
-        brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-        self.data_api_client.get_brief.return_value = brief_json
-
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"
-        )
-
-        assert res.status_code == 200
-        page_html = res.get_data(as_text=True)
-        document = html.fromstring(page_html)
-
-        assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-        assert self._get_links(document, self.GUIDANCE_LINKS_XPATH, text_only=True) == [
-            'View your published requirements',
-            'View and shortlist suppliers',
-            'How to shortlist suppliers',
-            'How to evaluate suppliers',
-            'How to award a contract',
-            'Download the Digital Outcomes and Specialists 4 contract',
-            'Let suppliers know the outcome'
-        ]
-
-        assert "Awarded to " not in page_html
-        assert self._get_links(document, self.SIDE_LINKS_XPATH) == [
-            (
-                'Cancel requirements',
-                '/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/cancel'
-            )
-        ]
-
-    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
     @pytest.mark.parametrize(
-        'status,award_description',
-        [('cancelled', 'the requirements were cancelled'), ('unsuccessful', 'no suitable suppliers applied')]
+        "task_name, brief_data",
+        [
+            ("Specialist role", {"specialistRole": "communicationsManager"}),
+            ("Location", {"location": "London"}),
+            (
+                "Description of work",
+                {
+                    "organisation": "Org Inc.",
+                    "specialistWork": "Werk.",
+                    "existingTeam": "Team members.",
+                    "workplaceAddress": "Townsville",
+                    "workingArrangements": "Arrangements.",
+                    "startDate": "Tomorrow.",
+                    "summary": "Summary.",
+                },
+            ),
+            (
+                "Shortlist and evaluation process",
+                {
+                    "numberOfSuppliers": 7,
+                    "technicalWeighting": 60,
+                    "culturalWeighting": 20,
+                    "priceWeighting": 20,
+                    "essentialRequirements": ["skills", "experience"],
+                    "culturalFitCriteria": ["cultural", "fit"],
+                },
+            ),
+            ("Set how long your requirements will be open for", {"requirementsLength": "1 week"},),
+            ("Describe question and answer session", {"questionAndAnswerSessionDetails": "Q&A."},),
+        ],
     )
-    def test_show_cancelled_and_unsuccessful_brief_summary_page_for_live_and_expired_framework(
-            self, status, award_description, framework_status):
-        self.data_api_client.get_framework.return_value = FrameworkStub(
-            slug='digital-outcomes-and-specialists-4',
-            status=framework_status,
-            lots=[
-                LotStub(slug='digital-specialists', allows_brief=True).response(),
-            ]
-        ).single_result_response()
-        brief_json = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-            status=status,
-        ).single_result_response()
-        brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-        brief_json['briefs']['specialistRole'] = 'communicationsManager'
-        brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-        self.data_api_client.get_brief.return_value = brief_json
+    def test_draft_brief_requirements_task_list_tasks_show_when_done(self, brief, task_name, brief_data):
+        document = self.get_requirements_task_list_page(brief)
 
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"
+        tag_selector = f".dm-task-list__task-name:contains('{task_name}') + .dm-task-list__tag"
+        tag = document.cssselect(tag_selector)[0]
+
+        assert tag.text.strip() in ["To do", "Optional"]
+
+        brief.update(brief_data)
+
+        document = self.get_requirements_task_list_page(brief)
+
+        tag = document.cssselect(tag_selector)[0]
+
+        assert tag.text.strip() == "Done"
+
+        # Only the Title task and the task we've just completed should say done
+        all_tags = document.cssselect(".dm-task-list__tag")
+        assert len([tag for tag in all_tags if tag.text.strip() == "Done"]) == 2
+
+    @pytest.mark.parametrize(
+        "task_name, brief_data",
+        [
+            ("Description of work", {"organisation": "Org Inc."}),
+            ("Description of work", {"specialistWork": "Werk."}),
+            ("Description of work", {"existingTeam": "Team members."}),
+            ("Description of work", {"workplaceAddress": "Townsville"}),
+            ("Description of work", {"workingArrangements": "Arrangements."}),
+            ("Description of work", {"startDate": "Tomorrow."}),
+            ("Description of work", {"summary": "Summary."}),
+            ("Shortlist and evaluation process", {"numberOfSuppliers": 7}),
+            ("Shortlist and evaluation process", {"technicalWeighting": 60}),
+            ("Shortlist and evaluation process", {"culturalWeighting": 20}),
+            ("Shortlist and evaluation process", {"priceWeighting": 20}),
+            ("Shortlist and evaluation process", {"essentialRequirements": ["skills", "experience"]},),
+            ("Shortlist and evaluation process", {"culturalFitCriteria": ["cultural", "fit"]},),
+        ],
+    )
+    def test_draft_brief_requirements_task_list_tasks_show_when_in_progress(self, brief, task_name, brief_data):
+        document = self.get_requirements_task_list_page(brief)
+
+        tag_selector = f".dm-task-list__task-name:contains('{task_name}') + .dm-task-list__tag"
+        tag = document.cssselect(tag_selector)[0]
+
+        assert tag.text.strip() == "To do"
+
+        brief.update(brief_data)
+
+        document = self.get_requirements_task_list_page(brief)
+
+        tag = document.cssselect(tag_selector)[0]
+
+        assert tag.text.strip() == "In progress"
+
+        # Only the the task we've just started should say in progress
+        all_tags = document.cssselect(".dm-task-list__tag")
+        assert len([tag for tag in all_tags if tag.text.strip() == "In progress"]) == 1
+
+    @pytest.mark.parametrize("lot_slug", ["digital-specialists", "digital-outcomes"])
+    @pytest.mark.parametrize("task_name", ["Preview your requirements", "Publish your requirements"])
+    def test_draft_brief_requirements_task_list_cannot_start_tasks(self, lot_slug, task_name):
+        self.data_api_client.get_framework.return_value = FrameworkStub(
+            slug="digital-outcomes-and-specialists-4",
+            status="live",
+            lots=[LotStub(slug=lot_slug, allows_brief=True).response()],
+        ).single_result_response()
+        self.data_api_client.get_brief.return_value = BriefStub(
+            framework_slug="digital-outcomes-and-specialists-4", lot_slug=lot_slug, status="draft",
+        ).single_result_response()
+        brief = self.data_api_client.get_brief.return_value["briefs"]
+
+        document = self.get_requirements_task_list_page(brief)
+
+        task_name_selector = f".dm-task-list__task-name:contains('{task_name}')"
+        tag_selector = f"{task_name_selector} + .dm-task-list__tag"
+        task_name = document.cssselect(task_name_selector)[0]
+        tag = document.cssselect(tag_selector)[0]
+
+        assert task_name.find("a") is None, "task should not be a link when it cannot be started"
+        assert tag.text.strip() == "Cannot start yet"
+
+        brief.update(
+            {
+                "specialistRole": "communicationsManager",
+                "location": "London",
+                "organisation": "Org Inc.",
+                "specialistWork": "Werk.",
+                "backgroundInformation": "Information.",
+                "outcome": "Problem to be solved.",
+                "endUsers": "Who the users are.",
+                "phase": "Alpha",
+                "existingTeam": "Team members.",
+                "workplaceAddress": "Townsville",
+                "workingArrangements": "Arrangements.",
+                "startDate": "Tomorrow.",
+                "summary": "Summary.",
+                "numberOfSuppliers": 7,
+                "technicalWeighting": 60,
+                "culturalWeighting": 20,
+                "priceWeighting": 20,
+                "essentialRequirements": ["skills", "experience"],
+                "culturalFitCriteria": ["cultural", "fit"],
+                "successCriteria": ["proposal", "evaluation"],
+                "priceCriteria": "fixedPrice",
+                "requirementsLength": "1 week",
+                "questionAndAnswerSessionDetails": "Q&A.",
+            }
         )
 
-        assert res.status_code == 200
-        page_html = res.get_data(as_text=True)
-        document = html.fromstring(page_html)
+        document = self.get_requirements_task_list_page(brief)
 
-        assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-        assert self._get_links(document, self.GUIDANCE_LINKS_XPATH, text_only=True) == [
-            'View your published requirements',
-            'View suppliers who applied',
-        ]
-        assert "The contract was not awarded - {}.".format(award_description) in page_html
+        task_name = document.cssselect(task_name_selector)[0]
+        tag = document.cssselect(tag_selector)[0]
 
-        assert "Awarded to " not in page_html
-        assert self._get_links(document, self.SIDE_LINKS_XPATH) == []
+        assert tag.text.strip() in ["Optional", "To do"]
+        assert task_name.find("a") is not None, "task should be a link when it can be started"
 
-    @pytest.mark.parametrize('framework_status', ['live', 'expired'])
-    def test_show_awarded_brief_summary_page_for_live_and_expired_framework(self, framework_status):
+    @mock.patch("app.main.views.requirement_task_list.content_loader", autospec=True)
+    def test_links_to_sections_go_to_the_correct_pages_whether_they_be_sections_or_questions(
+        self, content_loader, brief
+    ):  # noqa
+        content_fixture = ContentLoader("tests/fixtures/content")
+        content_fixture.load_manifest("dos", "data", "edit_brief")
+        content_loader.get_manifest.return_value = content_fixture.get_manifest("dos", "edit_brief")
+
+        document = self.get_requirements_task_list_page(brief)
+
+        section_steps = document.cssselect("ol.dm-task-list")
+        section_1_link = section_steps[0].xpath('li//a[contains(text(), "Section 1")]')
+        section_2_link = section_steps[0].xpath('li//a[contains(text(), "Section 2")]')
+        section_4_link = section_steps[0].xpath('li//a[contains(text(), "Section 4")]')
+
+        # section with multiple questions
+        assert (
+            section_1_link[0].get("href").strip()
+            == "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/section-1"
+        )
+        # section with single question
+        assert (
+            section_2_link[0].get("href").strip() == "/buyers/frameworks/digital-outcomes-and-specialists-4"
+            "/requirements/digital-specialists/1234/edit/section-2/required2"
+        )
+        # section with single question and a description
+        assert (
+            section_4_link[0].get("href").strip()
+            == "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/section-4"
+        )
+
+
+class TestRequirementsTaskListPageLiveBrief(BaseRequirementsTaskListPageTest, BaseApplicationTest):
+    """Test a live brief (one which has been published)
+
+    Live briefs can be on live or expired frameworks.
+    """
+
+    @pytest.fixture(autouse=True, params=["live", "expired"])
+    def brief(self, request):
+        """A live brief on a live or expired framework"""
+
+        framework_status = request.param
+
         self.data_api_client.get_framework.return_value = FrameworkStub(
-            slug='digital-outcomes-and-specialists-4',
+            slug="digital-outcomes-and-specialists-4",
             status=framework_status,
-            lots=[
-                LotStub(slug='digital-specialists', allows_brief=True).response(),
-            ]
+            lots=[LotStub(slug="digital-specialists", allows_brief=True).response()],
         ).single_result_response()
+
         brief_json = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-            status="awarded",
+            framework_slug="digital-outcomes-and-specialists-4", status="live",
         ).single_result_response()
-        brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-        brief_json['briefs']['specialistRole'] = 'communicationsManager'
-        brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-        brief_json['briefs']['awardedBriefResponseId'] = 999
+
+        brief_json["briefs"]["publishedAt"] = "2016-04-02T20:10:00.00000Z"
+        brief_json["briefs"]["specialistRole"] = "communicationsManager"
+        brief_json["briefs"]["clarificationQuestionsAreClosed"] = True
+
+        self.data_api_client.get_brief.return_value = brief_json
+
+        return brief_json["briefs"]
+
+    def test_live_brief_requirements_task_list(self, task_list_html, snapshot):
+        assert task_list_html == snapshot
+
+    def test_live_brief_requirements_task_list_page_has_link_to_withdraw(self, brief, requirements_task_list_page):
+        sidebar = requirements_task_list_page.cssselect("div.govuk-grid-column-one-third")[0]
+        sidebar_links = sidebar.cssselect("a.govuk-link")
+        assert len(sidebar_links) == 1
+
+        withdraw_link = sidebar_links[0]
+        assert withdraw_link.text == "Withdraw requirements"
+        assert withdraw_link.attrib["href"] == (
+            f"/buyers/frameworks/{brief['framework']['slug']}/requirements/{brief['lotSlug']}/{brief['id']}/withdraw"
+        )
+
+
+class TestRequirementsTaskListPageClosedBrief(BaseRequirementsTaskListPageTest, BaseApplicationTest):
+    """Test closed briefs
+
+    Closed briefs can be on live or expired frameworks.
+    """
+
+    @pytest.fixture(autouse=True, params=["live", "expired"])
+    def brief(self, request):
+        """A closed brief on a live or expired framework"""
+
+        framework_status = request.param
+
+        self.data_api_client.get_framework.return_value = FrameworkStub(
+            slug="digital-outcomes-and-specialists-4",
+            status=framework_status,
+            lots=[LotStub(slug="digital-specialists", allows_brief=True).response()],
+        ).single_result_response()
+
+        brief_json = BriefStub(
+            framework_slug="digital-outcomes-and-specialists-4", status="closed",
+        ).single_result_response()
+        brief_json["briefs"]["publishedAt"] = "2016-04-02T20:10:00.00000Z"
+        brief_json["briefs"]["specialistRole"] = "communicationsManager"
+        brief_json["briefs"]["clarificationQuestionsAreClosed"] = True
+        self.data_api_client.get_brief.return_value = brief_json
+
+        return brief_json["briefs"]
+
+    def test_closed_brief_requirements_task_list(self, task_list_html, snapshot):
+        assert task_list_html == snapshot
+
+    def test_closed_briefs_requirements_task_list_page_has_link_to_cancel(self, brief, requirements_task_list_page):
+        sidebar = requirements_task_list_page.cssselect("div.govuk-grid-column-one-third")[0]
+        sidebar_links = sidebar.cssselect("a.govuk-link")
+        assert len(sidebar_links) == 1
+
+        cancel_link = sidebar_links[0]
+        assert cancel_link.text == "Cancel requirements"
+        assert cancel_link.attrib["href"] == (
+            f"/buyers/frameworks/{brief['framework']['slug']}" f"/requirements/{brief['lotSlug']}/{brief['id']}/cancel"
+        )
+
+
+class TestRequirementsTaskListPageCancelledOrUnsuccessfulBrief(BaseRequirementsTaskListPageTest, BaseApplicationTest):
+    """Test briefs which were published and closed but had no successful responses"""
+
+    @pytest.fixture(autouse=True, params=["live", "expired"])
+    def framework(self, request):
+        framework_status = request.param
+
+        self.data_api_client.get_framework.return_value = FrameworkStub(
+            slug="digital-outcomes-and-specialists-4",
+            status=framework_status,
+            lots=[LotStub(slug="digital-specialists", allows_brief=True).response()],
+        ).single_result_response()
+
+        return self.data_api_client.get_framework.return_value["frameworks"]
+
+    @pytest.fixture(autouse=True, params=["cancelled", "unsuccessful"])
+    def brief(self, request):
+        brief_status = request.param
+
+        brief_json = BriefStub(
+            framework_slug="digital-outcomes-and-specialists-4", status=brief_status,
+        ).single_result_response()
+
+        brief_json["briefs"]["publishedAt"] = "2016-04-02T20:10:00.00000Z"
+        brief_json["briefs"]["specialistRole"] = "communicationsManager"
+        brief_json["briefs"]["clarificationQuestionsAreClosed"] = True
+
+        self.data_api_client.get_brief.return_value = brief_json
+
+        return brief_json["briefs"]
+
+    def test_cancelled_or_unsuccessful_brief_requirements_task_list(self, task_list_html, snapshot):
+        assert task_list_html == snapshot
+
+
+class TestRequirementsTaskListPageAwardedBrief(BaseRequirementsTaskListPageTest, BaseApplicationTest):
+    """Test briefs which have been awarded"""
+
+    @pytest.fixture(autouse=True, params=["live", "expired"])
+    def brief(self, request):
+        """An awarded brief on a live or expired framework"""
+
+        framework_status = request.param
+
+        self.data_api_client.get_framework.return_value = FrameworkStub(
+            slug="digital-outcomes-and-specialists-4",
+            status=framework_status,
+            lots=[LotStub(slug="digital-specialists", allows_brief=True).response()],
+        ).single_result_response()
+
+        brief_json = BriefStub(
+            framework_slug="digital-outcomes-and-specialists-4", status="awarded",
+        ).single_result_response()
+
+        brief_json["briefs"]["publishedAt"] = "2016-04-02T20:10:00.00000Z"
+        brief_json["briefs"]["specialistRole"] = "communicationsManager"
+        brief_json["briefs"]["clarificationQuestionsAreClosed"] = True
+        brief_json["briefs"]["awardedBriefResponseId"] = 999
+
         self.data_api_client.get_brief.return_value = brief_json
 
         self.data_api_client.get_brief_response.return_value = {
             "briefResponses": {
-                "awardDetails": {
-                    "awardedContractStartDate": "2016-4-4",
-                    "awardedContractValue": "100"
-                },
+                "awardDetails": {"awardedContractStartDate": "2016-4-4", "awardedContractValue": "100"},
                 "id": 213,
                 "status": "awarded",
                 "supplierName": "100 Percent IT Ltd",
             }
         }
 
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"
-        )
+        return brief_json["briefs"]
 
-        assert res.status_code == 200
+    def test_awarded_brief_requirements_task_list(self, task_list_html, snapshot):
+        assert task_list_html == snapshot
 
-        assert self.data_api_client.get_brief_response.call_args_list == [
-            mock.call(999)
-        ]
+    def test_awarded_brief_requirements_task_list_page_checks_brief_responses(self, brief, requirements_task_list_page):
+        assert self.data_api_client.get_brief_response.call_args_list == [mock.call(999)]
 
-        page_html = res.get_data(as_text=True)
-        document = html.fromstring(page_html)
+    def test_awarded_brief_requirements_task_list_page_includes_awarded_supplier(self, requirements_task_list_page):
+        assert "Awarded to 100 Percent IT Ltd" in requirements_task_list_page.text_content()
 
-        assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-        assert self._get_links(document, self.GUIDANCE_LINKS_XPATH, text_only=True) == [
-            'View your published requirements',
-            'View suppliers who applied',
-        ]
-        assert "Awarded to 100 Percent IT Ltd" in page_html
-        assert self._get_links(document, self.SIDE_LINKS_XPATH) == []
+
+class TestRequirementsTaskListPageAborts(BaseApplicationTest):
+    """Test situations in which the requirements task list page does not work"""
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch("app.main.views.requirement_task_list.data_api_client", autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+        self.data_api_client.get_framework.return_value = FrameworkStub(
+            slug="digital-outcomes-and-specialists-4",
+            status="live",
+            lots=[LotStub(slug="digital-specialists", allows_brief=True).response()],
+        ).single_result_response()
+
+        self.login_as_buyer()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
 
     def test_404_if_framework_does_not_allow_brief(self):
         self.data_api_client.get_framework.return_value = FrameworkStub(
-            slug='digital-outcomes-and-specialists-4',
-            status='live',
-            lots=[
-                LotStub(slug='digital-specialists', allows_brief=False).response(),
-            ]
+            slug="digital-outcomes-and-specialists-4",
+            status="live",
+            lots=[LotStub(slug="digital-specialists", allows_brief=False).response()],
         ).single_result_response()
 
         res = self.client.get(
@@ -401,8 +508,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
     def test_404_if_brief_does_not_belong_to_user(self):
         self.data_api_client.get_brief.return_value = BriefStub(
-            framework_slug="digital-outcomes-and-specialists-4",
-            user_id=234,
+            framework_slug="digital-outcomes-and-specialists-4", user_id=234,
         ).single_result_response()
 
         res = self.client.get(
@@ -418,30 +524,13 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
         assert res.status_code == 404
 
-    @mock.patch("app.main.views.requirement_task_list.content_loader", autospec=True)
-    def test_links_to_sections_go_to_the_correct_pages_whether_they_be_sections_or_questions(self, content_loader):  # noqa
-        content_fixture = ContentLoader('tests/fixtures/content')
-        content_fixture.load_manifest('dos', 'data', 'edit_brief')
-        content_loader.get_manifest.return_value = content_fixture.get_manifest('dos', 'edit_brief')
+    def test_404_if_brief_is_withdrawn(self):
+        self.data_api_client.get_brief.return_value = BriefStub(
+            framework_slug="digital-outcomes-and-specialists-4", status="withdrawn",
+        ).single_result_response()
 
         res = self.client.get(
             "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"
         )
 
-        assert res.status_code == 200
-
-        document = html.fromstring(res.get_data(as_text=True))
-        section_steps = document.cssselect("ol.dm-task-list")
-        section_1_link = section_steps[0].xpath('li//a[contains(text(), "Section 1")]')
-        section_2_link = section_steps[0].xpath('li//a[contains(text(), "Section 2")]')
-        section_4_link = section_steps[0].xpath('li//a[contains(text(), "Section 4")]')
-
-        # section with multiple questions
-        assert section_1_link[0].get('href').strip() == \
-            '/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/section-1'
-        # section with single question
-        assert section_2_link[0].get('href').strip() == \
-            '/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/edit/section-2/required2'  # noqa
-        # section with single question and a description
-        assert section_4_link[0].get('href').strip() == \
-            '/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/section-4'
+        assert res.status_code == 404

--- a/tests/main/views/test_requirement_task_list.py
+++ b/tests/main/views/test_requirement_task_list.py
@@ -279,9 +279,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             'How to shortlist suppliers',
             'How to evaluate suppliers',
             'How to award a contract',
-            'Download the Digital Outcomes and Specialists 4 contract'
-        ]
-        assert self._get_links(document, self.INSTRUCTION_LINKS_XPATH, text_only=True) == [
+            'Download the Digital Outcomes and Specialists 4 contract',
             'Let suppliers know the outcome'
         ]
 


### PR DESCRIPTION
https://trello.com/c/SPGKu5rX/95-3-replace-instruction-list-with-govuk-design-system-task-list-pages-pattern-in-create-a-dos-opportunity-journey

Have implemented a task list that's as close to the [prototype kit](https://github.com/alphagov/govuk-prototype-kit/blob/master/docs/views/templates/task-list.html) as possible so that hopefully if/when the task list gets added to the Design System, it should be fairly easy to convert and remove the custom styling.

Pages seem to be working as expected and passing old tests.


### To do
There are several more states now, and this needs to be tested more thoroughly:

* Correct tags show - To do, in progress, Done, Cannot start yet and Optional - depending on state of work. I've started on testing these, but I'm sure there's an easier way to do it that I haven't figured out.
* Preview/Publish text behaviour (initially unclickable, clickable once all required questions are answered). This is related to the above - what's the easiest way of generating a brief that's ready to preview, without having to manually enter all the answers in the test?
* The new `section_status` object behaviour should be tested - maybe testing its effect on the page is enough?


### Issues
* The mix of task list and normal links might be a bit messy, after all. Once you're past the draft stage, I think there's only one further "Task" that we check the state of: "Let suppliers know the outcome". So that's currently set up as a task list item. Would setting ALL the links up as Task List items also be confusing since we're not checking the state of all of them? What tag would we give things that are just providing guidance?

<img width="661" alt="Screenshot 2020-06-19 at 09 27 33" src="https://user-images.githubusercontent.com/22524634/85113420-28623600-b20f-11ea-97a3-a534c75b6a28.png">
