### PR TITLE
Remove DMSpeak from Create a DOS Opportunity start pages

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -56,17 +56,4 @@ $govuk-global-styles: true;
 @import "overrides/_govuk-label";
 @import "overrides/_summary-list.scss";
 
-// Misc styles
-// TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit
-
-.marketplace-paragraph {
-
-  h2 {
-    @include bold-27;
-    padding-bottom: 10px;
-  }
-  p {
-    padding-bottom: 30px;
-  }
-}
 

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -29,74 +29,69 @@
 {% block mainContent %}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds large-paragraph">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title_text }}</h1>
+      {% set digital_specialists_intro %}
+        <p class="govuk-body">You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.</p>
+        <p class="govuk-body">You need to write ‘requirements’ to describe the work and tell suppliers to provide a specialist. The specialist can’t work for you outside the scope of your written requirements.</p>
+      {% endset %}
+
+      {% set digital_outcomes_intro %}
+        <p class="govuk-body">You can use the Digital Marketplace to find a team to work on a digital outcome, such as a booking system or an accessibility audit.</p>
+        <p class="govuk-body">You need to write ‘requirements’ to describe the situation or problem and ask suppliers to propose a solution and provide a team.</p>
+        <p class="govuk-body">The members of the team can’t work for you outside the scope of your written requirements.</p>
+      {% endset %}
+
+      {% set user_research_participants_intro %}
+        <p class="govuk-body">To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.</p>
+      {% endset %}
+
+      {{
+        {
+        "digital-specialists": digital_specialists_intro,
+        "digital-outcomes": digital_outcomes_intro,
+        "user-research-participants": user_research_participants_intro,
+        }[lot.slug]
+      }}
+
+      <h2 class="govuk-heading-m">Before you start</h2>
+      <ol class="govuk-list govuk-list--number">
+        <li>You can talk to suppliers to prepare your requirements.<br>
+          <a class="govuk-link" href="https://assets.digitalmarketplace.service.gov.uk/{{ framework.slug }}/communications/catalogues/{{ lot.slug }}-suppliers.csv">
+            Download list of suppliers.
+          </a>
+        </li>
+        <li>Get budget approval.</li>
+      </ol>
+
+      <h2 class="govuk-heading-m">Write and publish your requirements</h2>
+      <ol class="govuk-list govuk-list--number" start="3">
+          <li>Write your requirements and say how you’re going to evaluate {{ "specialists" if lot.slug == "digital-specialists" else "suppliers" }}.</li>
+          <li>Publish your requirements and evaluation criteria so suppliers can apply for the work. This information will be published on the Digital Marketplace where anyone can see it.</li>
+      </ol>
+
+      <h2 class="govuk-heading-m">Answer supplier questions</h2>
+      <ol class="govuk-list govuk-list--number" start="5">
+        <li>Post all supplier questions and answers on the Digital Marketplace.</li>
+      </ol>
+
+      <h2 class="govuk-heading-m">Evaluate suppliers</h2>
+      <ol class="govuk-list govuk-list--number" start="6">
+        <li>Shortlist and evaluate {{ "specialists’" if lot.slug == "digital-specialists" else "supplier" }} applications.</li>
+        <li>Award a contract to the {{ "specialist" if lot.slug == "digital-specialists" else "supplier" }} that best meets your needs.</li>
+      </ol>
+
+      <p class="govuk-body">The buying process should take around 4 weeks.</p>
+      <p class="govuk-body">Read more about:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a class="govuk-link" href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">how to buy</a></li>
+        <li><a class="govuk-link" href="https://www.gov.uk/guidance/how-digital-marketplace-suppliers-have-been-evaluated">how suppliers have been evaluated</a></li>
+      </ul>
+
     </div>
 
-    <div class="govuk-grid-column-two-thirds large-paragraph">
-        <div class="marketplace-paragraph">
-                 {% set digital_specialists_intro %}
-                    <p class="govuk-body">You can use the Digital Marketplace to find a specialist, such as a developer or a user researcher, for a specific piece of work.</p>
-                    <p class="govuk-body">You need to write ‘requirements’ to describe the work and tell suppliers to provide a specialist. The specialist can’t work for you outside the scope of your written requirements.</p>
-                {% endset %}
-
-                 {% set digital_outcomes_intro %}
-                    <p class="govuk-body">You can use the Digital Marketplace to find a team to work on a digital outcome, such as a booking system or an accessibility audit.</p>
-                    <p class="govuk-body">You need to write ‘requirements’ to describe the situation or problem and ask suppliers to propose a solution and provide a team.</p>
-                    <p class="govuk-body">The members of the team can’t work for you outside the scope of your written requirements.</p>
-                {% endset %}
-
-                {% set user_research_participants_intro %}
-                    <p class="govuk-body">To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.</p>
-                {% endset %}
-
-                {{
-                    {
-                    "digital-specialists": digital_specialists_intro,
-                    "digital-outcomes": digital_outcomes_intro,
-                    "user-research-participants": user_research_participants_intro,
-                    }[lot.slug]
-                }}
-        </div>
-
-        <h2>Before you start</h2>
-        <ol class="govuk-list govuk-list--number">
-            <li>You can talk to suppliers to prepare your requirements.<br>
-                <a class="govuk-link" href="https://assets.digitalmarketplace.service.gov.uk/{{ framework.slug }}/communications/catalogues/{{ lot.slug }}-suppliers.csv">
-                    Download list of suppliers.
-                </a>
-            </li>
-            <li>Get budget approval.</li>
-        </ol>
-
-        <h2>Write and publish your requirements</h2>
-        <ol class="govuk-list govuk-list--number" start="3">
-            <li>Write your requirements and say how you’re going to evaluate {{ "specialists" if lot.slug == "digital-specialists" else "suppliers" }}.</li>
-            <li>Publish your requirements and evaluation criteria so suppliers can apply for the work. This information will be published on the Digital Marketplace where anyone can see it.</li>
-        </ol>
-
-        <h2>Answer supplier questions</h2>
-        <ol class="govuk-list govuk-list--number" start="5">
-            <li>Post all supplier questions and answers on the Digital Marketplace.</li>
-        </ol>
-
-        <h2>Evaluate suppliers</h2>
-        <ol class="govuk-list govuk-list--number" start="6">
-            <li>Shortlist and evaluate {{ "specialists’" if lot.slug == "digital-specialists" else "supplier" }} applications.</li>
-            <li>Award a contract to the {{ "specialist" if lot.slug == "digital-specialists" else "supplier" }} that best meets your needs.</li>
-        </ol>
-
-        <p class="govuk-body">The buying process should take around 4 weeks.</p>
-        <p class="govuk-body">Read more about:</p>
-        <div class="explanation-list">
-            <ul class="govuk-list govuk-list--bullet">
-                <li><a class="govuk-link" href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">how to buy</a></li>
-                <li><a class="govuk-link" href="https://www.gov.uk/guidance/how-digital-marketplace-suppliers-have-been-evaluated">how suppliers have been evaluated</a></li>
-            </ul>
-        </div>
-    </div>
-
-    <div class="govuk-grid-column-two-thirds large-paragraph">
+    <div class="govuk-grid-column-two-thirds">
         <form action="{{ url_for('buyers.start_new_brief', framework_slug=framework.slug, lot_slug=lot.slug) }}" method="get">
 
             {{ govukButton({

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -21,69 +21,60 @@
 {% block mainContent %}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds large-paragraph">
-      <h1 class="govuk-heading-l">Find a user research lab</h1>
-    </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Find a user research lab</h1>
+    
+    <p class="govuk-body">
+      To find a user research lab, you need to tell suppliers what facilities you need and when. They’ll then tell you what they can do and how much it will cost.
+    </p>
 
-    <div class="govuk-grid-column-two-thirds large-paragraph">
-        <div class="marketplace-paragraph">
-            <p class="govuk-body">
-                To find a user research lab, you need to tell suppliers what facilities you need and when. They’ll then tell you what they can do and how much it will cost.
-            </p>
-        </div>
+    <h2 class="govuk-heading-m">Before you start</h2>
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        Prepare your requirements and set evaluation criteria.<br />
+        For example: a lab in York with a desktop PC and an observation room
+      </li>
+      <li>Get approval to buy what you need.</li>
+    </ol>
 
-        <h2>Before you start</h2>
-        <ol class="govuk-list govuk-list--number">
-            <li>
-                Prepare your requirements and set evaluation criteria.<br />
-                eg a lab in York with a desktop PC and an observation room
-            </li>
-            <li>Get approval to buy what you need.</li>
-        </ol>
+    <h2 class="govuk-heading-m">Create a shortlist</h2>
+    <ol class="govuk-list govuk-list--number" start="3">
+      <li>Download the list of user research labs from the Digital Marketplace.</li>
+      <li>Filter the list of labs on location and your requirements to create a shortlist.</li>
+    </ol>
 
-        <h2>Create a shortlist</h2>
-        <ol class="govuk-list govuk-list--number" start="3">
-            <li>Download the list of user research labs from the Digital Marketplace.</li>
-            <li>Filter the list of labs on location and your requirements to create a shortlist.</li>
-        </ol>
+    <h2 class="govuk-heading-m">Contact your shortlist</h2>
+    <ol class="govuk-list govuk-list--number" start="5">
+      <li>
+        <a class="govuk-link" href="mailto:{{ support_email_address }}">Contact the Crown Commercial Service</a> to get contact details for the suppliers on your shortlist.
+      </li>
+      <li>Send your requirements and evaluation criteria to shortlisted suppliers.</li>
+      <li>Answer supplier questions.</li>
+      <li>Suppliers will tell you if they can meet your requirements.</li>
+    </ol>
 
-        <h2>Contact your shortlist</h2>
-        <ol class="govuk-list govuk-list--number" start="5">
-            <li>
-                Contact the <a class="govuk-link" href="mailto:{{ support_email_address }}">Crown Commercial Service</a>
-                to get contact details for the suppliers on your shortlist.
-            </li>
-            <li>Send your requirements and evaluation criteria to shortlisted suppliers.</li>
-            <li>Answer supplier questions.</li>
-            <li>Suppliers will tell you if they can meet your requirements.</li>
-        </ol>
+    <h2 class="govuk-heading-m">Evaluate</h2>
+    <ol class="govuk-list govuk-list--number" start="9">
+      <li>Evaluate suppliers responses on:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>availability</li>
+          <li>location, facilities and accessibility</li>
+          <li>price</li>
+        </ul>
+      </li>
+      <li>Award a contract to the supplier that best meets your needs.</li>
+    </ol>
 
-        <h2>Evaluate</h2>
-        <ol class="govuk-list govuk-list--number" start="9">
-            <li>Evaluate suppliers responses on:
-                <div class="explanation-list">
-                    <ul class="govuk-list govuk-list--bullet">
-                        <li>availability</li>
-                        <li>location, facilities and accessibility</li>
-                        <li>price</li>
-                    </ul>
-                </div>
-            </li>
-            <li>Award a contract to the supplier that best meets your needs.</li>
-        </ol>
+    <p class="govuk-body">Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
+        
+    <h2 class="govuk-heading-m">Download the list of labs</h2>
+    <a class="govuk-link govuk-!-display-inline-block govuk-!-margin-bottom-6" 
+        href="{{ 'https://assets.digitalmarketplace.service.gov.uk/{}/communications/catalogues/user-research-studios.csv'.format(framework.slug) }}"      
+    >List of labs (CSV)</a>
 
-        <div class="marketplace-paragraph">
-            <p class="govuk-body">Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
-        </div>
+    <p class="govuk-body">Get help filtering the list at <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
 
-        <h2>Download the list of labs</h2>
-        <a class="govuk-link govuk-!-display-inline-block govuk-!-margin-top-2 govuk-!-margin-bottom-6" 
-            href="{{ 'https://assets.digitalmarketplace.service.gov.uk/{}/communications/catalogues/user-research-studios.csv'.format(framework.slug) }}"      
-        >List of labs (CSV)</a>
-
-        <p class="govuk-body">Get help filtering the list at <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
-
-    </div>
+  </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
https://trello.com/c/i5M8XchI/98-2-remove-dmspeak-from-create-a-dos-opportunity-start-pages

* Styles removed
* `<h2>`'s set to `govuk-heading-m`

URLs affected:
`/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists`
`/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-outcomes`
`/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/user-research-studios`
`/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/user-research-participants`

