### PR TITLE
Apply GOV.UK Frontend styles to dos opportunity frameworks content

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -55,5 +55,6 @@ $govuk-global-styles: true;
 @import "overrides/_notifications_banner";
 @import "overrides/_govuk-label";
 @import "overrides/_summary-list.scss";
+@import "overrides/_question-advice.scss";
 
 

--- a/app/assets/scss/overrides/_question-advice.scss
+++ b/app/assets/scss/overrides/_question-advice.scss
@@ -1,0 +1,10 @@
+// TODO: remove this once we are no longer using toolkit/list-entry.html
+//       and have removed dmspeak.scss.
+
+.question-advice ul {
+  padding-bottom: 0px
+}
+
+.question-advice p {
+  margin-bottom: 20px
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,8 +2075,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#cddc728c11215467d026b6f8883a24f290a75065",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.2"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#99290ee125d589213b35a5e61dce39f7e59de089",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.2",
+    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.9.0",
     "govuk-elements-sass": "3.0.3",

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ Flask-Login==0.5.0
 Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.4.0#egg=digitalmarketplace-utils==52.4.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.9.0#egg=digitalmarketplace-content-loader==7.9.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.10.0#egg=digitalmarketplace-content-loader==7.10.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,8 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.9.0#egg=digitalmarketplace-content-loader==7.9.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.4.0#egg=digitalmarketplace-utils==52.4.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.10.0#egg=digitalmarketplace-content-loader==7.10.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2           # via digitalmarketplace-utils


### PR DESCRIPTION
https://trello.com/c/X4vKC3Bv/112-2-apply-govuk-frontend-styles-to-frameworks-content-for-the-create-a-dos-opportunity-journey

- Pulls in content loader changes for auto-adding `govuk-` classes for `<a>` and `<h2>`
- Pulls in utils changes to remove `app-break-link` class from `<a>`
- Pulls in frameworks changes to swap out bold text with `h2` (blocked on https://github.com/alphagov/digitalmarketplace-frameworks/pull/624).
- Adds a small SCSS override to negate the effects of `dmspeak`, which clashes with the GOVUK Frontend paragraph and list styles.

Before:
![preview-cultural-fit-criteria](https://user-images.githubusercontent.com/3492540/85315090-53b87f80-b4b2-11ea-87fb-16400af2b9b6.png)

After: 
![branch-cultural-fit-criteria](https://user-images.githubusercontent.com/3492540/85315234-8d898600-b4b2-11ea-8dee-aab61f6f3e1a.png)

So pretty! 😻 