### PR TITLE
Remove dmspeak classes from templates

### DIFF
--- a/app/assets/scss/_brief_submission.scss
+++ b/app/assets/scss/_brief_submission.scss
@@ -76,13 +76,3 @@ ol.steps {
     margin-left: (30 / 19) * -1em; // -25px in ems
   }
 }
-
-.section-description {
-  @extend %markdown-description;
-  padding-bottom: 30px;
-  h2 {
-    @extend %heading-small;
-    margin-bottom: -5px;
-  }
-}
-

--- a/app/assets/scss/_error-pages.scss
+++ b/app/assets/scss/_error-pages.scss
@@ -1,3 +1,0 @@
-.error-page {
-  @extend .dmspeak;
-}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -47,7 +47,6 @@ $govuk-global-styles: true;
 // App specific styles
 @import "_brief_submission.scss";
 @import "_text.scss";
-@import "_error-pages.scss";
 @import "_statistics.scss";
 @import "_iframe_preview.scss";
 
@@ -56,5 +55,6 @@ $govuk-global-styles: true;
 @import "overrides/_govuk-label";
 @import "overrides/_summary-list.scss";
 @import "overrides/_question-advice.scss";
+@import "overrides/_dmspeak.scss";
 
 

--- a/app/assets/scss/overrides/_dmspeak.scss
+++ b/app/assets/scss/overrides/_dmspeak.scss
@@ -1,0 +1,9 @@
+/**
+ * These styles maintain compatibility with the toolkit components which use them.
+ * They are not present in Briefs FE app templates.
+ * They should be removed once Briefs FE no longer uses DM-Frontend-Toolkit
+ */
+
+.error-page {
+    @extend .dmspeak;
+}

--- a/app/assets/scss/overrides/_dmspeak.scss
+++ b/app/assets/scss/overrides/_dmspeak.scss
@@ -4,6 +4,17 @@
  * They should be removed once Briefs FE no longer uses DM-Frontend-Toolkit
  */
 
+ // Error pages simply use all the .dmspeak styling
 .error-page {
     @extend .dmspeak;
+}
+
+// %markdown-description and %heading-small are both toolkit placeholder selectors
+.section-description {
+  @extend %markdown-description;
+  padding-bottom: 30px;
+  h2 {
+    @extend %heading-small;
+    margin-bottom: -5px;
+  }
 }

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -40,47 +40,35 @@
   <div class="govuk-grid-column-two-thirds">
     {% set heading = "Publish your requirements and evaluation criteria" if not published else "Question and answer dates" %}
     <h1 class="govuk-heading-l">{{ heading }}</h1>
-    {% if not published %}
-      <div class="dmspeak">
-        <p class="govuk-body">All requirements are published on the Digital Marketplace where anyone can see them.</p>
-      </div>
-        {% if brief.lotSlug == 'digital-specialists' and not brief.requirementsLength %}
-          <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
-          <div class="dmspeak">
-            <p class="govuk-body">This will show you what the supplier application deadline will be if you publish your requirements today.</p>
-          </div>
-        {% else %}
-          <p class="govuk-body">Your requirements will be open for {{ dates.application_open_weeks }}.</p>
-          <div class="dmspeak">
-            <p class="govuk-body">If you publish your requirements today ({{ dates.published_date | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_date | utcdatetimeformat }}.</p>
-          </div>
-        {% endif %}
-    {% endif %}
+    {% if not published -%}
+      <p class="govuk-body">All requirements are published on the Digital Marketplace where anyone can see them.</p>
+      {% if brief.lotSlug == 'digital-specialists' and not brief.requirementsLength -%}
+        <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
+        <p class="govuk-body">This will show you what the supplier application deadline will be if you publish your requirements today.</p>
+      {% else -%}
+        <p class="govuk-body">Your requirements will be open for {{ dates.application_open_weeks }}.</p>
+        <p class="govuk-body">If you publish your requirements today ({{ dates.published_date | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_date | utcdatetimeformat }}.</p>
+      {% endif %}
+    {% endif -%}
 
     <p class="govuk-body">Supplier questions will be sent to:</p>
-    <div class="dmspeak">
-      <p class="govuk-body">{{ email_address }}</p>
-    </div>
-    <div class="dmspeak">
-      <p class="govuk-body">Make sure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
-    </div>
+    <p class="govuk-body">{{ email_address }}</p>
+    <p class="govuk-body">Make sure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
 
-    {% if not published and unanswered_required > 0 %}
-      <div class="dmspeak">
-        <p class="govuk-body"><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
-      </div>
+    {%- if not published and unanswered_required > 0 %}
+      <p class="govuk-body"><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
       <ul class="govuk-list govuk-list--bullet">
-      {% for section in sections %}
-        {% for question in section.questions %}
-          {% if question.answer_required and not question.id == 'requirementsLength' %}
+      {%- for section in sections %}
+        {%- for question in section.questions %}
+          {%- if question.answer_required and not question.id == 'requirementsLength' %}
             <li>
               <a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
             </li>
-          {% endif %}
-        {% endfor %}
-      {% endfor %}
+          {%- endif %}
+        {%- endfor %}
+      {%- endfor %}
       </ul>
-    {% elif brief.lotSlug != 'digital-specialists' or brief.requirementsLength %}
+    {% elif brief.lotSlug != 'digital-specialists' or brief.requirementsLength -%}
       {% import "toolkit/summary-table.html" as summary %}
         {% call summary.mapping_table(
         row_bold_borders=True,
@@ -139,7 +127,7 @@
           }) }}
         </form>
       {% endif %}
-    {% endif %}
+    {%- endif %}
     <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
        href="{{ url_for('.view_brief_overview', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
       Return to overview

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -37,7 +37,7 @@
 {% block mainContent %}
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds large-paragraph">
+  <div class="govuk-grid-column-two-thirds">
     {% set heading = "Publish your requirements and evaluation criteria" if not published else "Question and answer dates" %}
     <h1 class="govuk-heading-l">{{ heading }}</h1>
     {% if not published %}

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -51,16 +51,14 @@
     <div class="govuk-grid-column-two-thirds">
       {% if response_counts['eligible'] > 0 %}
         {% if brief_responses_required_evidence %}
-          <div class="dmspeak">
-              <p class="govuk-body">
-                <span class='visual-emphasis'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
-                responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience.
-                Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
-              </p>
-              <p class="govuk-body">
-                You said you’d take <span class='visual-emphasis'>{{ brief.numberOfSuppliers }} {{ pluralize(brief.numberOfSuppliers, "supplier", "suppliers") }}</span> through to the evaluation stage. To do this, you need to:
-              </p>
-          </div>
+          <p class="govuk-body">
+            <span class='govuk-!-font-weight-bold'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
+            responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience.
+            Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
+          </p>
+          <p class="govuk-body">
+            You said you’d take <span class='govuk-!-font-weight-bold'>{{ brief.numberOfSuppliers }} {{ pluralize(brief.numberOfSuppliers, "supplier", "suppliers") }}</span> through to the evaluation stage. To do this, you need to:
+          </p>
           <ol class="govuk-list govuk-list--number">
             <li>Read the <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">guidance on how to shortlist.</a></li>
             <li>Review and score the evidence suppliers have given.</li>
@@ -76,16 +74,14 @@
           </div>
 
         {% else %}
-          <div class="dmspeak">
-            <p class="govuk-body">
-                <span class='visual-emphasis'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
-                responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience.
-                Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
-            </p>
-            <p class="govuk-body">
-              Download the list of supplier responses and follow the guidance on <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">how to shortlist</a>.
-            </p>
-          </div>
+          <p class="govuk-body">
+              <span class='govuk-!-font-weight-bold'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
+              responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience.
+              Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
+          </p>
+          <p class="govuk-body">
+            Download the list of supplier responses and follow the guidance on <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">how to shortlist</a>.
+          </p>
 
           <div class="govuk-width-full">
             <a class="govuk-link" 
@@ -96,16 +92,14 @@
 
         {% endif %}
       {% else %}
-        <div class="dmspeak">
+        <p class="govuk-body">
+            No suppliers met your essential skills and experience requirements.
+        </p>
+        {% if (response_counts['eligible'] or response_counts['failed']) and not brief_responses_required_evidence %}
           <p class="govuk-body">
-              No suppliers met your essential skills and experience requirements.
+              All the suppliers who applied have already been told they were unsuccessful.
           </p>
-          {% if (response_counts['eligible'] or response_counts['failed']) and not brief_responses_required_evidence %}
-            <p class="govuk-body">
-                All the suppliers who applied have already been told they were unsuccessful.
-            </p>
-          {% endif %}
-        </div>
+        {% endif %}
         <p class="govuk-body-l">
           If you still need this service, you should start the buying process again. Consider:
         </p>

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -106,15 +106,13 @@
             </p>
           {% endif %}
         </div>
-        <div class='explanation-list'>
-            <p class="govuk-body-l">
-                If you still need this service, you should start the buying process again. Consider:
-            </p>
-            <ul class='govuk-list govuk-list--bullet'>
-                <li>talking to suppliers before you start</li>
-                <li>rewriting your requirements</li>
-            </ul>
-        </div>
+        <p class="govuk-body-l">
+          If you still need this service, you should start the buying process again. Consider:
+        </p>
+        <ul class='govuk-list govuk-list--bullet'>
+            <li>talking to suppliers before you start</li>
+            <li>rewriting your requirements</li>
+        </ul>
       {% endif %}
       <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
          href="{{ url_for('buyers.view_brief_overview', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">

--- a/app/templates/buyers/index.html
+++ b/app/templates/buyers/index.html
@@ -28,33 +28,31 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds dm-account-overview-options">
 
-    <div class="dmspeak">
-      <h2 class="heading-xmedium">Cloud hosting, software and support</h2>
-      <p class="govuk-body">
-        {% if user_has_projects %}
-          {% if user_projects_awaiting_outcomes_total %}
-            You need to tell us the outcome for {{ user_projects_awaiting_outcomes_total }}
-            {{ pluralize(user_projects_awaiting_outcomes_total, "saved search", "saved searches") }}.<br>
-          {% endif %}
-          <a class="govuk-link" href="/buyers/direct-award/g-cloud">View your saved searches</a><br>
-        {% else %}
-          You don't have any saved searches.
+    <h2 class="govuk-heading-m">Cloud hosting, software and support</h2>
+    <p class="govuk-body">
+      {% if user_has_projects %}
+        {% if user_projects_awaiting_outcomes_total %}
+          You need to tell us the outcome for {{ user_projects_awaiting_outcomes_total }}
+          {{ pluralize(user_projects_awaiting_outcomes_total, "saved search", "saved searches") }}.<br>
         {% endif %}
-      </p>
+        <a class="govuk-link" href="/buyers/direct-award/g-cloud">View your saved searches</a><br>
+      {% else %}
+        You don't have any saved searches.
+      {% endif %}
+    </p>
 
-      <h2 class="heading-xmedium">Digital outcomes, specialists and user research participants</h2>
-      <p class="govuk-body">
-        {% if user_briefs_total %}
-          <a class="govuk-link" href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>
-        {% else %}
-          You don't have any requirements.
-        {% endif %}
-      </p>
-    </div>
+    <h2 class="govuk-heading-m">Digital outcomes, specialists and user research participants</h2>
+    <p class="govuk-body">
+      {% if user_briefs_total %}
+        <a class="govuk-link" href="{{ url_for('buyers.buyer_dos_requirements') }}">View your requirements</a><br>
+      {% else %}
+        You don't have any requirements.
+      {% endif %}
+    </p>
 
   </div>
-  <div class="govuk-grid-column-one-third dmspeak">
-    <h2 class="heading-xmedium">Account settings</h2>
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">Account settings</h2>
     <ul class="govuk-list">
       <li>
         <a class="govuk-link" href="{{ url_for('external.change_password') }}">Change your password</a>

--- a/app/templates/buyers/preview_brief.html
+++ b/app/templates/buyers/preview_brief.html
@@ -47,19 +47,17 @@
   <div class="govuk-grid-column-full">
 
     {% if unanswered_required %}
-      <div class="dmspeak">
-        <p class="govuk-body">You still need to complete the following questions before your requirements can be previewed:</p>
-      </div>
+      <p class="govuk-body">You still need to complete the following questions before your requirements can be previewed:</p>
       <ul class="govuk-list govuk-list--bullet">
-      {% for section in content.summary(brief) %}
-        {% for question in section.questions %}
-          {% if question.answer_required %}
+      {%- for section in content.summary(brief) %}
+        {%- for question in section.questions %}
+          {%- if question.answer_required %}
             <li>
               <a class="govuk-link" href="{{ url_for('.edit_brief_question', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
             </li>
-          {% endif %}
-        {% endfor %}
-      {% endfor %}
+          {%- endif %}
+        {%- endfor %}
+      {%- endfor %}
       </ul>
     {% else %}
       <p class="govuk-body">This is how suppliers see your requirements when they are published.</p>

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -47,9 +47,7 @@
   {% if section.description %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <div class="section-description">
-        {{ section.description }}
-      </div>
+      {{ section.description }}
     </div>
   </div>
   {% endif %}

--- a/app/templates/create_buyer/create_buyer_user_error.html
+++ b/app/templates/create_buyer/create_buyer_user_error.html
@@ -9,7 +9,7 @@
 {% if error == 'invalid_buyer_domain' %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds error-page">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
         You must use a public sector email address
       </h1>


### PR DESCRIPTION
https://trello.com/c/rALi76lP/118-2-remove-dmspeak-from-briefs-frontend

Removes:
  - `dmspeak`
  - `marketplace-paragraph`
  - `large-paragraph`
  - `explanation-list`
  - `error-page`
  - `markdown-description`

Keeps:
  - `single-question-page` (due to required functionality - see ticket)