### PR TITLE
Replace instruction list with normal `<ol>`

### DIFF
--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -61,23 +61,12 @@
                 You said you’d take <span class='visual-emphasis'>{{ brief.numberOfSuppliers }} {{ pluralize(brief.numberOfSuppliers, "supplier", "suppliers") }}</span> through to the evaluation stage. To do this, you need to:
               </p>
           </div>
-          {% with items = [
-              {
-                  "body": 'Read the <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">guidance on how to shortlist.</a>'|safe,
-              },
-              {
-                  "body": 'Review and score the evidence suppliers have given.',
-              },
-              {
-                  "body": 'Tell the highest scoring suppliers that they’re through to the next stage.',
-              },
-              {
-                  "body": 'Tell any unsuccessful suppliers who don\'t make it through to the next stage.',
-              }
-          ]
-          %}
-              {% include "toolkit/instruction-list.html" %}
-          {% endwith %}
+          <ol class="govuk-list govuk-list--number">
+            <li>Read the <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">guidance on how to shortlist.</a></li>
+            <li>Review and score the evidence suppliers have given.</li>
+            <li>Tell the highest scoring suppliers that they’re through to the next stage.</li>
+            <li>Tell any unsuccessful suppliers who don't make it through to the next stage.</li>
+          </ol>
           
           <div class="govuk-width-full">
             <a class="govuk-link" 


### PR DESCRIPTION
Noticed this while working on #330 

Think we can probably replace this simple instruction list with a normal list.

## Before
![Screenshot 2020-07-22 at 16 15 15](https://user-images.githubusercontent.com/22524634/88194378-abbfde80-cc36-11ea-878b-33d9f64a3b68.png)

## After
![Screenshot 2020-07-22 at 16 14 57](https://user-images.githubusercontent.com/22524634/88194399-b1b5bf80-cc36-11ea-985b-22f176c429e4.png)

