### PR TITLE
Use govukInput for text questions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ from flask_login import LoginManager
 from flask_wtf.csrf import CSRFProtect
 
 import dmapiclient
+import dmcontent.govuk_frontend
 from dmutils import init_app
 from dmutils.user import User
 
@@ -52,6 +53,11 @@ def create_app(config_name):
     login_manager.login_message = None  # don't flash message to user
     gds_metrics.init_app(application)
     csrf.init_app(application)
+
+    # We want to be able to access this function from within all templates
+    application.jinja_env.globals["govuk_frontend_from_question"] = (
+        dmcontent.govuk_frontend.from_question
+    )
 
     @application.before_request
     def remove_trailing_slash():

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -53,6 +53,7 @@ $govuk-global-styles: true;
 // Overrides
 @import "overrides/_notifications_banner";
 @import "overrides/_govuk-label";
+@import "overrides/_govuk-hint";
 @import "overrides/_summary-list.scss";
 @import "overrides/_question-advice.scss";
 @import "overrides/_dmspeak.scss";

--- a/app/assets/scss/overrides/_govuk-hint.scss
+++ b/app/assets/scss/overrides/_govuk-hint.scss
@@ -1,0 +1,6 @@
+// We want to put the question advice or other text in the hint box for
+// govuk-frontend components, but have it styled as normal text.
+
+.app-hint--text {
+  @extend %govuk-body-m;
+}

--- a/app/assets/scss/overrides/_govuk-label.scss
+++ b/app/assets/scss/overrides/_govuk-label.scss
@@ -13,3 +13,8 @@
 
   margin-bottom: govuk-spacing(2);
 }
+
+.govuk-label--l {
+  @include govuk-font($size: 36, $weight: bold);
+  margin-bottom: govuk-spacing(3);
+}

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
+
 {% import "toolkit/forms/macros/forms.html" as forms %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
 
 {% block pageTitle %}
   {{ question.question }} – Digital Marketplace
@@ -31,6 +33,8 @@
             {% if is_govuk_frontend %}
               {% set govuk_forms = {"govukInput": govukInput} %}
               {% set form = govuk_frontend_from_question(question, brief, errors) %}
+              {{ govukLabel(form.label) }}
+              {{ question.question_advice }}
               {{ govuk_forms[form.macro_name](form.params) }}
             {% elif errors and errors[question.id] %}
               {{ forms[question.type](question, brief, errors) }}

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -7,10 +7,13 @@
 
 {% block mainContent %}
 
+  {% set is_govuk_frontend = govuk_frontend_from_question(question) %}
+
   {% if question.type != 'multiquestion' %}
     <div class="single-question-page">
   {% endif %}
 
+  {% if not is_govuk_frontend %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
@@ -18,13 +21,18 @@
       </h1>
     </div>
   </div>
+  {% endif %}
 
   <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
           {% if question.type != 'multiquestion' %}
-            {% if errors and errors[question.id] %}
+            {% if is_govuk_frontend %}
+              {% set govuk_forms = {"govukInput": govukInput} %}
+              {% set form = govuk_frontend_from_question(question, brief, errors) %}
+              {{ govuk_forms[form.macro_name](form.params) }}
+            {% elif errors and errors[question.id] %}
               {{ forms[question.type](question, brief, errors) }}
             {% else %}
               {{ forms[question.type](question, brief, {}) }}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ const path = require('path')
 const sourcemaps = require('gulp-sourcemaps')
 
 // Paths
-let environment
+let environment = 'development'
 const repoRoot = path.join(__dirname)
 const npmRoot = path.join(repoRoot, 'node_modules')
 const govukToolkitRoot = path.join(npmRoot, 'govuk_frontend_toolkit')

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.11.0#egg=digitalmarketplace-content-loader==7.11.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.12.0#egg=digitalmarketplace-content-loader==7.12.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.3-alpha#egg=govuk-frontend-jinja==0.5.3-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.11.0#egg=digitalmarketplace-content-loader==7.11.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.12.0#egg=digitalmarketplace-content-loader==7.12.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore


### PR DESCRIPTION
https://trello.com/c/YXsBOrDK/110-3-replace-text-boxes-with-govuk-frontend-text-input-component-in-create-a-dos-opportunity-journey

Uses alphagov/digitalmarketplace-content-loader#90 to render questions with `type: text` with GOV.UK Design System text input components.