### PR TITLE
Replace banners-with-actions with confirm-action page

### DIFF
--- a/app/main/views/requirement_task_list.py
+++ b/app/main/views/requirement_task_list.py
@@ -34,8 +34,6 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
 
     content = content_loader.get_manifest(brief['frameworkSlug'], 'edit_brief').filter({'lot': brief['lotSlug']})
     sections = content.summary(brief)
-    delete_requested = request.args.get('delete_requested') and brief['status'] == 'draft'
-    withdraw_requested = request.args.get('withdraw_requested') and brief['status'] == 'live'
 
     content_loader.load_messages(brief['frameworkSlug'], ['urls'])
     call_off_contract_url = content_loader.get_message(brief['frameworkSlug'], 'urls', 'call_off_contract_url')
@@ -104,8 +102,6 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
         sections=sections,
         completed_sections=completed_sections,
         step_sections=[section.step for section in sections if hasattr(section, 'step')],
-        delete_requested=delete_requested,
-        withdraw_requested=withdraw_requested,
         call_off_contract_url=call_off_contract_url,
         framework_agreement_url=framework_agreement_url,
         awarded_brief_response_supplier_name=awarded_brief_response_supplier_name,

--- a/app/main/views/withdraw_brief.py
+++ b/app/main/views/withdraw_brief.py
@@ -1,6 +1,8 @@
 from flask import abort, flash, redirect, url_for
 from flask_login import current_user
 
+from dmutils.flask import timed_render_template as render_template
+
 from app import data_api_client
 from .. import main
 from ..helpers.buyers_helpers import (
@@ -8,8 +10,28 @@ from ..helpers.buyers_helpers import (
     is_brief_correct,
 )
 
-
 BRIEF_WITHDRAWN_MESSAGE = "You’ve withdrawn your requirements for ‘{brief[title]}’"
+
+
+@main.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/withdraw', methods=['GET'])
+def withdraw_a_brief_warning(framework_slug, lot_slug, brief_id):
+    framework, lot = get_framework_and_lot(
+        framework_slug,
+        lot_slug,
+        data_api_client,
+        allowed_statuses=['live', 'expired'],
+        must_allow_brief=True
+    )
+    brief = data_api_client.get_brief(brief_id)["briefs"]
+
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id, allowed_statuses=['live']):
+        abort(404)
+
+    return render_template(
+        "buyers/withdraw_brief.html",
+        framework=framework,
+        brief=brief,
+    ), 200
 
 
 @main.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/withdraw', methods=['POST'])
@@ -28,5 +50,4 @@ def withdraw_a_brief(framework_slug, lot_slug, brief_id):
 
     data_api_client.withdraw_brief(brief_id, current_user.email_address)
     flash(BRIEF_WITHDRAWN_MESSAGE.format(brief=brief), "success")
-
     return redirect(url_for(".buyer_dos_requirements"))

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -30,56 +30,6 @@
 
 {% block mainContent %}
   <div class="govuk-grid-row">
-    {% block before_heading %}
-      {% if delete_requested %}
-        <div class="govuk-grid-column-full">
-          <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-            <input type="hidden" name="delete_confirmed" value="true" />
-            {%
-              with
-              message = "Are you sure you want to delete these requirements?",
-              type = "destructive",
-              action = govukButton({
-                "text": "Yes, delete",
-                "classes": "govuk-button--warning app-banner-action",
-              })
-            %}
-              {% include "toolkit/notification-banner.html" %}
-            {% endwith %}
-          </form>
-        </div>
-      {% endif %}
-      {% if withdraw_requested %}
-        <div class="govuk-grid-column-full">
-          <form action="{{ url_for('buyers.withdraw_a_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-            <input type="hidden" name="withdraw_confirmed" value="true" />
-            {% set withdraw_text = "You should only withdraw your requirements if you:" %}
-            {% set withdraw_list_items = [
-                "want to change something that may affect whether suppliers apply, for example, the budget range or role",
-                "can no longer offer the work"
-              ]
-            %}
-            {%
-              with
-              heading = "Are you sure you want to withdraw these requirements?",
-              banner_content = "<p class='govuk-body'>{}</p><ul class='govuk-list govuk-list--bullet'><li>{}</li></ul>".format(withdraw_text, withdraw_list_items|join("</li><li>"))|safe,
-              type = "destructive",
-              action = govukButton({
-                "text": "Withdraw requirements",
-                "classes": "govuk-button--warning app-banner-action",
-              })
-            %}
-              {% include "toolkit/notification-banner.html" %}
-            {% endwith %}
-          </form>
-        </div>
-      {% endif %}
-    {% endblock %}
-  </div>
-
-  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">{{ brief.get('title', brief['lotName']) }}</h1>
     </div>
@@ -279,13 +229,9 @@
       {% if brief.status == 'closed' %}
         <a class="govuk-link" href="{{ url_for('buyers.cancel_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel requirements</a>
       {% elif brief.status == 'live' %}
-        {% if not withdraw_requested %}
-          <a class="govuk-link" href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, withdraw_requested=True) }}">Withdraw requirements</a>
-        {% endif %}
+        <a class="govuk-link" href="{{ url_for('buyers.withdraw_a_brief_warning', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Withdraw requirements</a>
       {% elif brief.status == 'draft' %}
-        {% if not delete_requested %}
-          <a class="govuk-link" href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, delete_requested=True) }}">Delete draft requirements</a>
-        {% endif %}
+        <a class="govuk-link" href="{{ url_for('buyers.delete_a_brief_warning', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Delete draft requirements</a>
       {% endif %}
     </div>
   </div>

--- a/app/templates/buyers/delete_brief.html
+++ b/app/templates/buyers/delete_brief.html
@@ -1,0 +1,65 @@
+{% extends "_base_page.html" %}
+
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% block pageTitle %}
+  {{ brief.title or brief.lotName }}: Are you sure you want to delete these requirements? – Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+  {{ govukBreadcrumbs({
+    "items": [
+        {
+          "href": "/",
+          "text": "Digital Marketplace"
+      },
+      {
+          "href": url_for("buyers.buyer_dashboard"),
+          "text": "Your account"
+      },
+      {
+          "href": url_for("buyers.buyer_dos_requirements"),
+          "text": "Your requirements"
+      },
+      {
+        "href": url_for(
+            ".view_brief_overview",
+            framework_slug=brief.framework.slug,
+            lot_slug=brief['lotSlug'],
+            brief_id=brief['id']),
+        "text": brief['title']
+      },
+      {
+          "text": "Are you sure you want to delete these requirements?"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-xl">{{ brief.get('title', brief['lotName']) }}</span>
+        <h1 class="govuk-heading-xl">Are you sure you want to delete these requirements?</h1>
+
+        {{ govukWarningText({
+        "text": "This action is final and cannot be undone.",
+        "iconFallbackText": "Warning",
+        "classes": "govuk-!-margin-bottom-8"
+        }) }}
+
+        <form method="post" action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" novalidate>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            
+            {{ govukButton({
+                "text": "Yes, delete",
+                "classes": "govuk-button--warning govuk-!-margin-right-3",
+                "name": "delete_confirmed"
+            }) }}
+            
+            <a class="govuk-button govuk-button--secondary" href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel</a>
+
+        </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/buyers/withdraw_brief.html
+++ b/app/templates/buyers/withdraw_brief.html
@@ -1,0 +1,71 @@
+{% extends "_base_page.html" %}
+
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% block pageTitle %}
+  {{ brief.title or brief.lotName }}: Are you sure you want to withdraw these requirements? – Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+  {{ govukBreadcrumbs({
+    "items": [
+        {
+          "href": "/",
+          "text": "Digital Marketplace"
+      },
+      {
+          "href": url_for("buyers.buyer_dashboard"),
+          "text": "Your account"
+      },
+      {
+          "href": url_for("buyers.buyer_dos_requirements"),
+          "text": "Your requirements"
+      },
+      {
+        "href": url_for(
+            ".view_brief_overview",
+            framework_slug=brief.framework.slug,
+            lot_slug=brief['lotSlug'],
+            brief_id=brief['id']),
+        "text": brief['title']
+      },
+      {
+          "text": "Are you sure you want to withdraw these requirements?"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-xl">{{ brief.get('title', brief['lotName']) }}</span>
+        <h1 class="govuk-heading-xl">Are you sure you want to withdraw these requirements?</h1>
+
+        <p class="govuk-body">Only withdraw your requirements if:</p>
+        <ul class="govuk-list govuk-list--bullet">
+        <li>you want to change something that may affect whether suppliers apply</li>
+        <li>the work is no longer available</li>
+        </ul>
+
+        {{ govukWarningText({
+        "text": "This action is final and cannot be undone.",
+        "iconFallbackText": "Warning",
+        "classes": "govuk-!-margin-bottom-8"
+        }) }}
+
+        <form method="post" action="{{ url_for('buyers.withdraw_a_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" novalidate>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            
+            {{ govukButton({
+                "text": "Withdraw requirements",
+                "classes": "govuk-button--warning govuk-!-margin-right-3",
+                "name": "withdraw_confirmed"
+            }) }}
+
+            <a class="govuk-button govuk-button--secondary" href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel</a>
+
+        </form>
+    </div>
+  </div>
+{% endblock %}

--- a/tests/main/views/test_requirement_task_list.py
+++ b/tests/main/views/test_requirement_task_list.py
@@ -85,11 +85,10 @@ class TestBriefSummaryPage(BaseApplicationTest):
         ]
 
         assert "Awarded to " not in page_html
-        assert 'Are you sure you want to delete these requirements?' not in page_html  # Delete banner hidden
         assert self._get_links(document, self.SIDE_LINKS_XPATH) == [
             (
                 "Delete draft requirements",
-                "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234?delete_requested=True"  # noqa
+                "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/delete"  # noqa
             )
         ]
 
@@ -109,12 +108,10 @@ class TestBriefSummaryPage(BaseApplicationTest):
         ).single_result_response()
 
         res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234?delete_requested=True"  # noqa
+            "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234"  # noqa
         )
 
         assert res.status_code == 200
-        page_html = res.get_data(as_text=True)
-        assert ('Are you sure you want to delete these requirements?' in page_html) == banner_displayed
 
     @pytest.mark.parametrize('framework_status', ['live', 'expired'])
     def test_show_live_brief_summary_page_for_live_and_expired_framework(self, framework_status):
@@ -155,11 +152,10 @@ class TestBriefSummaryPage(BaseApplicationTest):
         ]
 
         assert "Awarded to " not in page_html
-        assert 'Are you sure you want to withdraw these requirements?' not in page_html  # Withdraw banner hidden
         assert self._get_links(document, self.SIDE_LINKS_XPATH) == [
             (
                 'Withdraw requirements',
-                "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234?withdraw_requested=True"  # noqa
+                "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/digital-specialists/1234/withdraw"  # noqa
             )
         ]
 
@@ -183,8 +179,6 @@ class TestBriefSummaryPage(BaseApplicationTest):
         )
 
         assert res.status_code == 200
-        page_html = res.get_data(as_text=True)
-        assert ('Are you sure you want to withdraw these requirements?' in page_html) == banner_displayed
 
     @pytest.mark.parametrize('framework_status', ['live', 'expired'])
     def test_show_closed_brief_summary_page_for_live_and_expired_framework(self, framework_status):


### PR DESCRIPTION
https://trello.com/c/JhIzksR3/116-2-replace-banners-with-actions-with-confirm-action-page-pattern

Withdrawing and deleting briefs now show a separate confirmation page.

Functional tests here: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/781