### PR TITLE
Add support for govuk-frontend radios component

### DIFF
--- a/app/assets/scss/overrides/_govuk-label.scss
+++ b/app/assets/scss/overrides/_govuk-label.scss
@@ -18,3 +18,7 @@
   @include govuk-font($size: 36, $weight: bold);
   margin-bottom: govuk-spacing(3);
 }
+
+.govuk-radios__label {
+  @include govuk-font($size: 19)
+}

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -1,20 +1,33 @@
 {% extends "_base_page.html" %}
 
-{% import "toolkit/forms/macros/forms.html" as forms %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
 {% from "digitalmarketplace/components/list-input/macro.njk" import dmListInput %}
+
+{% import "toolkit/forms/macros/forms.html" as forms %}
 
 {%- macro show_question(is_govuk_frontend, question, brief, errors, is_only_question=True) %}
   {% if is_govuk_frontend %}
     {% set form = govuk_frontend_from_question(question, brief, errors, is_page_heading=is_only_question) %}
-    {% set govuk_forms = {"govukInput": govukInput, "dmListInput": dmListInput} %}
+    {% set govuk_forms = {"govukInput": govukInput, "govukRadios": govukRadios, "dmListInput": dmListInput} %}
     {%- if form.label %}
       {{ govukLabel(form.label) }}
     {% endif -%}
-    {% if not form.params.question_advice %}
-      {{ question.question_advice }}
+    {% if form.fieldset %}
+      {% call govukFieldset(form.fieldset) %}
+        {% if not form.params.question_advice %}
+          {{ question.question_advice }}
+        {% endif %}
+        {{ govuk_forms[form.macro_name](form.params) }}
+      {% endcall %}
+    {% else %}
+      {% if not form.params.question_advice %}
+        {{ question.question_advice }}
+      {% endif %}
+      {{ govuk_forms[form.macro_name](form.params) }}
     {% endif %}
-    {{ govuk_forms[form.macro_name](form.params) }}
   {% elif errors and errors[question.id] %}
     {{ forms[question.type](question, brief, errors) }}
   {% else %}

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ Flask-Login==0.5.0
 Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.14.0#egg=digitalmarketplace-content-loader==7.14.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.15.0#egg=digitalmarketplace-content-loader==7.15.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.3-alpha#egg=govuk-frontend-jinja==0.5.3-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.15.0#egg=digitalmarketplace-content-loader==7.15.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@ldeb-add-govuk-radios#egg=digitalmarketplace-content-loader==7.15.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,8 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.14.0#egg=digitalmarketplace-content-loader==7.14.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.15.0#egg=digitalmarketplace-content-loader==7.15.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2           # via digitalmarketplace-utils


### PR DESCRIPTION
Ticket: https://trello.com/c/6xOXfwx7/123-2-use-radios-component-for-radios-questions-in-create-a-dos-opportunity-journey

Pulls in changes from https://github.com/alphagov/digitalmarketplace-content-loader/pull/97 so questions with type radios will now use the GOV.UK Design System component.

A bit of rejigging of the macro for creating forms was needed so it could support either labels or fieldsets, and it's a bit messy now sadly. But it seems to work and we can iterate on it.