### PR TITLE
Add support for govuk-frontend character count component

### DIFF
--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -4,6 +4,7 @@
 {% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "digitalmarketplace/components/list-input/macro.njk" import dmListInput %}
 
 {% import "toolkit/forms/macros/forms.html" as forms %}
@@ -11,7 +12,12 @@
 {%- macro show_question(is_govuk_frontend, question, brief, errors, is_only_question=True) %}
   {% if is_govuk_frontend %}
     {% set form = govuk_frontend_from_question(question, brief, errors, is_page_heading=is_only_question) %}
-    {% set govuk_forms = {"govukInput": govukInput, "govukRadios": govukRadios, "dmListInput": dmListInput} %}
+    {% set govuk_forms = {
+      "govukInput": govukInput, 
+      "govukRadios": govukRadios, 
+      "dmListInput": dmListInput, 
+      "govukCharacterCount": govukCharacterCount
+    } %}
     {%- if form.label %}
       {{ govukLabel(form.label) }}
     {% endif -%}

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.15.0#egg=digitalmarketplace-content-loader==7.15.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.16.0#egg=digitalmarketplace-content-loader==7.16.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.3-alpha#egg=govuk-frontend-jinja==0.5.3-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.15.0#egg=digitalmarketplace-content-loader==7.15.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.16.0#egg=digitalmarketplace-content-loader==7.16.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore

--- a/tests/main/views/test_supplier_questions.py
+++ b/tests/main/views/test_supplier_questions.py
@@ -341,7 +341,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         assert res.status_code == 400
-        assert len(document.cssselect(".validation-message")) == 1, res.get_data(as_text=True)
+        assert len(document.cssselect(".govuk-form-group--error")) == 1, res.get_data(as_text=True)
 
     def test_api_error(self):
         brief_json = BriefStub(


### PR DESCRIPTION
https://trello.com/c/xHVb6nOe/117-2-replace-textarea-component-in-create-a-dos-opportunity-journey

Pulls in changes from https://github.com/alphagov/digitalmarketplace-content-loader/pull/96 so questions with type textbox_large use the [Design System component](https://design-system.service.gov.uk/components/character-count/).