### PR TITLE
Add support for govuk-frontend checkboxes component

### DIFF
--- a/app/assets/scss/overrides/_govuk-label.scss
+++ b/app/assets/scss/overrides/_govuk-label.scss
@@ -19,6 +19,6 @@
   margin-bottom: govuk-spacing(3);
 }
 
-.govuk-radios__label {
+.govuk-radios__label, .govuk-checkboxes__label {
   @include govuk-font($size: 19)
 }

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -3,6 +3,7 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "digitalmarketplace/components/list-input/macro.njk" import dmListInput %}
@@ -14,7 +15,8 @@
     {% set form = govuk_frontend_from_question(question, brief, errors, is_page_heading=is_only_question) %}
     {% set govuk_forms = {
       "govukInput": govukInput, 
-      "govukRadios": govukRadios, 
+      "govukRadios": govukRadios,
+      "govukCheckboxes": govukCheckboxes,
       "dmListInput": dmListInput, 
       "govukCharacterCount": govukCharacterCount
     } %}

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.16.0#egg=digitalmarketplace-content-loader==7.16.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.18.0#egg=digitalmarketplace-content-loader==7.18.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.3-alpha#egg=govuk-frontend-jinja==0.5.3-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.16.0#egg=digitalmarketplace-content-loader==7.16.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.18.0#egg=digitalmarketplace-content-loader==7.18.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore


### PR DESCRIPTION
https://trello.com/c/zx1hJsgX/114-2-replace-checkboxes-in-create-a-dos-opportunity-journey

Pulls in changes from https://github.com/alphagov/digitalmarketplace-content-loader/pull/98 so questions with type 'checkboxes' use the [Design System component](https://design-system.service.gov.uk/components/checkboxes/).