### PR TITLE
Add support for govuk-frontend date input component

### DIFF
--- a/app/assets/scss/overrides/_govuk-label.scss
+++ b/app/assets/scss/overrides/_govuk-label.scss
@@ -19,6 +19,6 @@
   margin-bottom: govuk-spacing(3);
 }
 
-.govuk-radios__label, .govuk-checkboxes__label {
+.govuk-radios__label, .govuk-checkboxes__label, .govuk-date-input__label {
   @include govuk-font($size: 19)
 }

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -4,6 +4,7 @@
 {% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "digitalmarketplace/components/list-input/macro.njk" import dmListInput %}
@@ -17,6 +18,8 @@
       "govukInput": govukInput, 
       "govukRadios": govukRadios,
       "govukCheckboxes": govukCheckboxes,
+      "govukDateInput": govukDateInput, 
+      "govukRadios": govukRadios, 
       "dmListInput": dmListInput, 
       "govukCharacterCount": govukCharacterCount
     } %}


### PR DESCRIPTION
https://trello.com/c/k2SADNQr/172-2-replace-date-input-component-in-create-a-dos-opportunity-journey

Pulls in changes from alphagov/digitalmarketplace-content-loader#99 so questions with type 'date' use the Design System component.

## Notes
We don't currently do granular error checking for date inputs, and this component reflects that. The [Design System component](https://design-system.service.gov.uk/components/date-input/) does recommend error messages are specific, but I think that's out of scope for this ticket.