### PR TITLE
Replace WTForms toolkit elements with govuk-frontend components on DOS Opportunity journey

### DIFF
--- a/app/main/views/outcome.py
+++ b/app/main/views/outcome.py
@@ -16,7 +16,7 @@ from ..forms.award_or_cancel import AwardOrCancelBriefForm
 from dmapiclient import HTTPError
 from dmutils.flask import timed_render_template as render_template
 from dmutils.forms.errors import govuk_errors
-from dmutils.forms.helpers import get_errors_from_wtform
+from dmutils.forms.helpers import get_errors_from_wtform, govuk_options
 
 BRIEF_UPDATED_MESSAGE = "You’ve updated ‘{brief[title]}’"
 
@@ -97,6 +97,7 @@ def award_brief(framework_slug, lot_slug, brief_id):
         )
 
     form = AwardedBriefResponseForm(brief_responses)
+    form_options = govuk_options(form.brief_response.toolkit_macro_options)
 
     if form.validate_on_submit():
         try:
@@ -126,6 +127,7 @@ def award_brief(framework_slug, lot_slug, brief_id):
         "buyers/award.html",
         brief=brief,
         form=form,
+        form_options=form_options,
         errors=errors
     ), 200 if not errors else 400
 

--- a/app/main/views/outcome.py
+++ b/app/main/views/outcome.py
@@ -174,6 +174,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
         )
 
     form = CancelBriefForm(brief, label_text)
+    form_options = govuk_options(form.cancel_reason.toolkit_macro_options)
 
     if form.validate_on_submit():
         new_status = form.data.get('cancel_reason')
@@ -203,6 +204,7 @@ def cancel_brief(framework_slug, lot_slug, brief_id):
         "buyers/cancel_brief.html",
         brief=brief,
         form=form,
+        form_options=form_options,
         errors=errors,
         previous_page_url=previous_page_url
     ), 200 if not errors else 400

--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -1,4 +1,5 @@
 {% extends "_base_page.html" %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 
 {% block pageTitle %}
   {{ brief.title or brief.lotName }} – Digital Marketplace
@@ -37,43 +38,65 @@
 
 {% block mainContent %}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-          <div class="single-question-page">
-              <h1 class="govuk-heading-l">Who won the {{ brief.title }} contract?</h1>
+  <div class="govuk-grid-column-two-thirds">
+    <div class="single-question-page">
+      <form method="POST" action="{{ url_for('.award_brief', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-              <form method="POST" action="{{ url_for('.award_brief', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
-                  <p class="govuk-body">
-                      This information will be added to your requirements. Suppliers will receive a link to view the update.
-                  </p>
-                  <p class="govuk-body">
-                      You’ll still need to contact suppliers to give them feedback.
-                  </p>
+        <div class="govuk-form-group {%- if errors %} govuk-form-group--error{% endif %}">
+          <fieldset class="govuk-fieldset" {%- if errors %} aria-describedby="brief_response-error" {% endif -%}>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Who won the {{ brief.title }} contract?
+              </h1>
+            </legend>
 
-                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                    {%
-                      with
-                      name = "brief_response",
-                      question = "Which supplier won the contract?",
-                      type = "radio",
-                      options = form.brief_response.toolkit_macro_options,
-                      value = form.brief_response.data,
-                      error = errors.get('brief_response', {}).get('message', None)
-                    %}
-                      {% include "toolkit/forms/selection-buttons.html" %}
-                    {% endwith %}
+            <p class="govuk-body">
+                This information will be added to your requirements. Suppliers will receive a link to view the update.
+            </p>
+            <p class="govuk-body">
+                You’ll still need to contact suppliers to give them feedback.
+            </p>
 
-                    {% block save_button %}
-                      {{ govukButton({
-                        "text": "Save and continue",
-                        "name": "save_and_continue",
-                      }) }}
-                    {% endblock %}
-              </form>
-              <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
-                  href="{{ url_for('.award_or_cancel_brief', framework_slug=brief.framework.slug, lot_slug=brief['lotSlug'], brief_id=brief['id']) }}">
-                Previous page
-              </a>
-          </div>
+            <div class="govuk-radios">
+              {% if errors %}
+                {{ govukErrorMessage({
+                  "id": "brief_response-error",
+                  "text": errors.get('brief_response', {}).get('message', None)
+                })}}
+              {% endif %}
+              {% for item in form_options %}
+                {% set checked = item.value == form.brief_response.data %}
+                {% if item %}
+                  {%- if loop.first -%}
+                    {%- set id = "brief_response" %}
+                  {% else %}
+                    {%- set id = "brief_response-" ~ loop.index -%}
+                  {%- endif -%}
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="{{ id }}" name="brief_response" type="radio" value="{{ item.value }}" {%- if checked %} checked {% endif -%}>
+                    <label class="govuk-label govuk-radios__label" for="{{ id }}">
+                      {{ item.text }}
+                    </label>
+                  </div>
+                {% endif %}
+              {% endfor %}
+            </div>
+          </fieldset>
+        </div>
+
+        {% block save_button %}
+          {{ govukButton({
+            "text": "Save and continue",
+            "name": "save_and_continue",
+          }) }}
+        {% endblock %}
+      </form>
+      <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
+          href="{{ url_for('.award_or_cancel_brief', framework_slug=brief.framework.slug, lot_slug=brief['lotSlug'], brief_id=brief['id']) }}">
+        Previous page
+      </a>
     </div>
+  </div>
 </div>
 {% endblock %}

--- a/app/templates/buyers/award_or_cancel_brief.html
+++ b/app/templates/buyers/award_or_cancel_brief.html
@@ -1,6 +1,5 @@
 {% extends "_base_page.html" %}
-
-{% import "toolkit/forms/macros/forms.html" as forms %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block pageTitle %}
   {{ brief.title or brief.lotName }} – Digital Marketplace
@@ -47,20 +46,28 @@
             <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">View the outcome of the requirements</a>
           </p>
       {% else %}
-          <h1 class="govuk-heading-l">{{ form.award_or_cancel_decision.label.text }}</h1>
           <form method="POST" action="{{ url_for('.award_or_cancel_brief', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            {%
-                  with
-                  name = "award_or_cancel_decision",
-                  question = form.award_or_cancel_decision.label.text,
-                  type = "radio",
-                  options = form.award_or_cancel_decision.toolkit_macro_options,
-                  value = form.award_or_cancel_decision.data,
-                  error = errors.get('award_or_cancel_decision', {}).get('message', None)
-                  %}
-              {% include "toolkit/forms/selection-buttons.html" %}
-            {% endwith %}
+
+            {{ govukRadios({
+              "idPrefix": "input-award_or_cancel_decision",
+              "name": "award_or_cancel_decision",
+              "items": [
+                {"id": "award_or_cancel_decision", "text": "Yes", "value": "yes"},
+                {"text": "No", "value": "no"},
+                {"text": "We are still evaluating suppliers", "value": "back"},
+              ],
+              "errorMessage": {
+                "text": errors.get('award_or_cancel_decision', {}).get('message', None)
+              } if errors,
+              "fieldset": {
+                "legend": {
+                  "text": form.award_or_cancel_decision.label.text,
+                  "isPageHeading": True,
+                  "classes": "govuk-fieldset__legend--l",
+                }
+              }
+            })}}
 
             {% block save_button %}
               {{ govukButton({

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -1,6 +1,5 @@
 {% extends "_base_page.html" %}
-
-{% import "toolkit/forms/macros/forms.html" as forms %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 
 {% block pageTitle %}
   {{ brief.title or brief.lotName }} – Digital Marketplace
@@ -40,26 +39,50 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="single-question-page">
-        <h1 class="govuk-heading-l">{{ form.cancel_reason.label.text }}</h1>
         <form method="POST" action="{{ url_for(request.endpoint, framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          <p class="govuk-body">
-              This information will be added to your requirements. Suppliers will receive a link to view the update.
-          </p>
-          <p class="govuk-body">
-              You’ll still need to contact suppliers to give them feedback.
-          </p>
-          {%
-            with
-            name = "cancel_reason",
-            question = form.cancel_reason.label.text,
-            type = "radio",
-            options = form.cancel_reason.toolkit_macro_options,
-            value = form.cancel_reason.data,
-            error = errors.get('cancel_reason', {}).get('message', None)
-          %}
-            {% include "toolkit/forms/selection-buttons.html" %}
-          {% endwith %}
+          
+          <div class="govuk-form-group {%- if errors %} govuk-form-group--error{% endif %}">
+            <fieldset class="govuk-fieldset" {%- if errors %} aria-describedby="cancel_reason-error" {% endif -%}>
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">
+                  {{ form.cancel_reason.label.text }}
+                </h1>
+              </legend>
+          
+              <p class="govuk-body">
+                  This information will be added to your requirements. Suppliers will receive a link to view the update.
+              </p>
+              <p class="govuk-body">
+                  You’ll still need to contact suppliers to give them feedback.
+              </p>
+
+              <div class="govuk-radios">
+                {% if errors %}
+                  {{ govukErrorMessage({
+                    "id": "cancel_reason-error",
+                    "text": errors.get('cancel_reason', {}).get('message', None)
+                  })}}
+                {% endif %}
+                {% for item in form_options %}
+                  {% set checked = item.value == form.cancel_reason.data %}
+                  {% if item %}
+                    {%- if loop.first -%}
+                      {%- set id = "cancel_reason" %}
+                    {% else %}
+                      {%- set id = "cancel_reason-" ~ loop.index -%}
+                    {%- endif -%}
+                    <div class="govuk-radios__item">
+                      <input class="govuk-radios__input" id="{{ id }}" name="cancel_reason" type="radio" value="{{ item.value }}" {%- if checked %} checked {% endif -%}>
+                      <label class="govuk-label govuk-radios__label" for="{{ id }}">
+                        {{ item.text }}
+                      </label>
+                    </div>
+                  {% endif %}
+                {% endfor %}
+              </div>
+            </fieldset>
+          </div>
 
           {% block save_button %}
             {{ govukButton({

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -672,10 +672,10 @@ class TestAwardOrCancelBrief(BaseApplicationTest):
         res = self.client.post(self.url.format(brief_id=123))
 
         document = html.fromstring(res.get_data(as_text=True))
-        validation_message = document.xpath('//span[@class="validation-message"]')[0].text_content()
+        error_message = document.xpath('//span[@class="govuk-error-message"]')[0].text_content()
 
         assert res.status_code == 400
-        assert "Select if you have awarded a contract." in validation_message
+        assert "Select if you have awarded a contract." in error_message
         assert self.data_api_client.cancel_brief.called is False
 
     def test_yes_redirects_to_award_form_page(self):
@@ -720,7 +720,7 @@ class TestAwardOrCancelBrief(BaseApplicationTest):
         res = self.client.post(self.url.format(brief_id=self.brief['id']), data={'award_or_cancel_decision': 'foo'})
 
         document = html.fromstring(res.get_data(as_text=True))
-        validation_message = document.xpath('//span[@class="validation-message"]')[0].text_content()
+        error_message = document.xpath('//span[@class="govuk-error-message"]')[0].text_content()
 
         assert res.status_code == 400
-        assert "Not a valid choice" in validation_message
+        assert "Not a valid choice" in error_message

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -549,10 +549,10 @@ class TestCancelBrief(BaseApplicationTest):
         res = self.client.post(self.url.format(brief_id=123))
 
         document = html.fromstring(res.get_data(as_text=True))
-        validation_message = document.xpath('//span[@class="validation-message"]')[0].text_content()
+        error_message = document.xpath('//span[@class="govuk-error-message"]')[0].text_content()
 
         assert res.status_code == 400
-        assert "Select a reason for cancelling the brief." in validation_message
+        assert "Select a reason for cancelling the brief." in error_message
 
     def test_that_no_option_chosen_does_not_trigger_update(self):
         res = self.client.post(self.url.format(brief_id=123))


### PR DESCRIPTION
https://trello.com/c/yHSxrqS9/173-3-replace-wtforms-toolkit-elements-with-govuk-frontend-components-in-award-a-dos-opportunity-journey

I've left the WTForms classes as they are and mostly focused on the view/template here.

I've had to hard-code into the template rather than use components for a couple of the pages because we have paragraphs between the heading and the radios that can't be handled by the GOVUK Frontend components, but we also want everything to be linked as a fieldset.

Currently running functional tests locally.