### PR TITLE
Use govuk frontend components on Award Details page

### DIFF
--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -1,50 +1,7 @@
 {% extends "_base_page.html" %}
 
-{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
-{% from "govuk/components/label/macro.njk" import govukLabel %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-
-{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
-{% from "digitalmarketplace/components/list-input/macro.njk" import dmListInput %}
-
 {% import "toolkit/forms/macros/forms.html" as forms %}
-
-{%- macro show_question(is_govuk_frontend, question, brief, errors, is_only_question=True) %}
-  {% if is_govuk_frontend %}
-    {% set form = govuk_frontend_from_question(question, brief, errors, is_page_heading=is_only_question) %}
-    {% set govuk_forms = {
-      "govukInput": govukInput, 
-      "govukRadios": govukRadios,
-      "govukCheckboxes": govukCheckboxes,
-      "govukDateInput": govukDateInput, 
-      "govukRadios": govukRadios, 
-      "dmListInput": dmListInput, 
-      "govukCharacterCount": govukCharacterCount
-    } %}
-    {%- if form.label %}
-      {{ govukLabel(form.label) }}
-    {% endif -%}
-    {% if form.fieldset %}
-      {% call govukFieldset(form.fieldset) %}
-        {% if not form.params.question_advice %}
-          {{ question.question_advice }}
-        {% endif %}
-        {{ govuk_forms[form.macro_name](form.params) }}
-      {% endcall %}
-    {% else %}
-      {% if not form.params.question_advice %}
-        {{ question.question_advice }}
-      {% endif %}
-      {{ govuk_forms[form.macro_name](form.params) }}
-    {% endif %}
-  {% elif errors and errors[question.id] %}
-    {{ forms[question.type](question, brief, errors) }}
-  {% else %}
-    {{ forms[question.type](question, brief, {}) }}
-  {% endif %}
-{% endmacro -%}
+{% import "macros/show_question.html" as show_question %}
 
 {% block pageTitle %}
   {{ question.question }} – Digital Marketplace
@@ -72,7 +29,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
           {% if question.type != 'multiquestion' %}
-            {{ show_question(is_govuk_frontend, question, brief, errors) }}
+            {{ show_question.show_question(is_govuk_frontend, question, brief, errors) }}
           {% else %}
             {% if question.question_advice %}
               <span class="question-advice">
@@ -81,7 +38,7 @@
             {% endif %}
             {% for question in question.questions %}
               {% set is_govuk_frontend = govuk_frontend_from_question(question) %}
-              {{ show_question(is_govuk_frontend, question, brief, errors, is_only_question=False) }}
+              {{ show_question.show_question(is_govuk_frontend, question, brief, errors, is_only_question=False) }}
             {% endfor %}
           {% endif %}
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
 {% import "toolkit/forms/macros/forms.html" as forms %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% import "macros/show_question.html" as show_question %}
 
 {% block pageTitle %}
   {{ brief.title or brief.lotName }} – Digital Marketplace
@@ -42,13 +44,10 @@
       <h1 class="govuk-heading-l">Tell us about your contract with {{ pending_brief_response.supplierName }}</h1>
       <form method="POST" action="{{ url_for('.award_brief_details', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, brief_response_id=pending_brief_response.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          {% for question in section.questions %}
-            {{ forms[question.type](
-                question,
-                data,
-                errors if errors and (errors[question.id] or question.type == 'multiquestion') else {},
-                )
-            }}
+
+          {% for question in section.questions %}  
+            {% set is_govuk_frontend = govuk_frontend_from_question(question) %}
+            {{ show_question.show_question(is_govuk_frontend, question, data, errors, is_only_question=False) }}
           {% endfor %}
 
           {% block save_button %}

--- a/app/templates/macros/show_question.html
+++ b/app/templates/macros/show_question.html
@@ -1,0 +1,45 @@
+{% import "toolkit/forms/macros/forms.html" as forms %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "digitalmarketplace/components/list-input/macro.njk" import dmListInput %}
+
+{%- macro show_question(is_govuk_frontend, question, brief, errors, is_only_question=True) %}
+  {% if is_govuk_frontend %}
+    {% set form = govuk_frontend_from_question(question, brief, errors, is_page_heading=is_only_question) %}
+    {% set govuk_forms = {
+      "govukInput": govukInput, 
+      "govukRadios": govukRadios,
+      "govukCheckboxes": govukCheckboxes,
+      "govukDateInput": govukDateInput, 
+      "dmListInput": dmListInput, 
+      "govukCharacterCount": govukCharacterCount
+    } %}
+    {%- if form.label %}
+      {{ govukLabel(form.label) }}
+    {% endif -%}
+    {% if form.fieldset %}
+      {% call govukFieldset(form.fieldset) %}
+        {% if not form.params.question_advice %}
+          {{ question.question_advice }}
+        {% endif %}
+        {{ govuk_forms[form.macro_name](form.params) }}
+      {% endcall %}
+    {% else %}
+      {% if not form.params.question_advice %}
+        {{ question.question_advice }}
+      {% endif %}
+      {{ govuk_forms[form.macro_name](form.params) }}
+    {% endif %}
+  {% elif errors and errors[question.id] %}
+    {{ forms[question.type](question, brief, errors) }}
+  {% else %}
+    {{ forms[question.type](question, brief, {}) }}
+  {% endif %}
+{% endmacro -%}

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.18.0#egg=digitalmarketplace-content-loader==7.18.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.18.1#egg=digitalmarketplace-content-loader==7.18.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.3-alpha#egg=govuk-frontend-jinja==0.5.3-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.18.0#egg=digitalmarketplace-content-loader==7.18.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.18.1#egg=digitalmarketplace-content-loader==7.18.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -352,7 +352,7 @@ class TestAwardBriefDetails(BaseApplicationTest):
 
         assert res.status_code == 400
         self._assert_error_summary(document)
-        error_spans = document.xpath('//span[@class="validation-message"]')
+        error_spans = document.cssselect('span.validation-message, span.govuk-error-message')
         # assert that framework iteration specific messages have been rendered
         assert len(self._strip_whitespace(error_spans[0].text_content())) > 0
         assert len(self._strip_whitespace(error_spans[1].text_content())) > 0
@@ -380,9 +380,10 @@ class TestAwardBriefDetails(BaseApplicationTest):
         self._assert_error_summary(document)
 
         # Individual error messages
-        error_spans = document.xpath('//span[@class="validation-message"]')
-        assert self._strip_whitespace(error_spans[0].text_content()) == "Enterarealstartdate."
-        assert self._strip_whitespace(error_spans[1].text_content()) == \
+        date_error_span = document.xpath('//span[@class="govuk-error-message"]')
+        value_error_span = document.xpath('//span[@class="validation-message"]')
+        assert self._strip_whitespace(date_error_span[0].text_content()) == "Error:Enterarealstartdate."
+        assert self._strip_whitespace(value_error_span[0].text_content()) == \
             "Enterthevalueinpoundsandpence,usingnumbersanddecimalsonly."
 
         # Prefilled form input


### PR DESCRIPTION
@katstevens pointed out this page was using content-loader but hadn't yet been switched over to govuk frontend components, so this PR does that.

I've pulled out the macro which was on `base_edit_question_page` so we can use it in multiple spots.

Related PR:
https://github.com/alphagov/digitalmarketplace-content-loader/pull/100