### PR TITLE
Install digitalmarketplace-govuk-frontend and govuk-frontend separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ target/
 # Front end dependencies
 node_modules
 npm-debug.log
+app/assets/scss/govuk
 app/assets/scss/toolkit
 app/templates/govuk
 app/templates/toolkit

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,7 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
-//= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk/all.js
+//= require ../../../node_modules/govuk-frontend/all.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all.js
 //= require _onready.js'
 //= require _selection-buttons.js

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -38,7 +38,7 @@ $govuk-fonts-path: '/buyers/static/fonts/';
 $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govukelements: true;
 $govuk-global-styles: true;
-@import "node_modules/digitalmarketplace-govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/all";
 
 // Digital Marketplace Components
 @import "node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all";

--- a/config.py
+++ b/config.py
@@ -69,12 +69,16 @@ class Config(object):
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
         digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
+        govuk_frontend = os.path.join(repo_root, "node_modules", "govuk-frontend")
         template_folders = [
             os.path.join(repo_root, 'app', 'templates'),
             os.path.join(digitalmarketplace_govuk_frontend),
             os.path.join(digitalmarketplace_govuk_frontend, "digitalmarketplace", "templates"),
         ]
-        jinja_loader = jinja2.FileSystemLoader(template_folders)
+        jinja_loader = jinja2.ChoiceLoader([
+            jinja2.FileSystemLoader(template_folders),
+            jinja2.PrefixLoader({'govuk': jinja2.FileSystemLoader(govuk_frontend)})
+        ])
         app.jinja_loader = jinja_loader
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ const repoRoot = path.join(__dirname)
 const npmRoot = path.join(repoRoot, 'node_modules')
 const govukToolkitRoot = path.join(npmRoot, 'govuk_frontend_toolkit')
 const govukElementsRoot = path.join(npmRoot, 'govuk-elements-sass')
-const govukFrontendRoot = path.join(npmRoot, 'digitalmarketplace-govuk-frontend', 'govuk')
+const govukFrontendRoot = path.join(npmRoot, 'govuk-frontend')
 const dmToolkitRoot = path.join(npmRoot, 'digitalmarketplace-frontend-toolkit', 'toolkit')
 const sspContentRoot = path.join(npmRoot, 'digitalmarketplace-frameworks')
 const assetsFolder = path.join(repoRoot, 'app', 'assets')
@@ -135,6 +135,17 @@ function copyFactory (resourceName, sourceFolder, targetFolder) {
       })
   }
 }
+gulp.task(
+  'copy:govuk_frontend:stylesheets',
+  function () {
+    return gulp
+      .src(path.join(govukFrontendRoot, '**', '*.scss'), { base: govukFrontendRoot })
+      .pipe(gulp.dest(path.join('app', 'assets', 'scss', 'govuk')))
+      .on('end', function () {
+        console.log('📂  Copied stylesheets from GOV.UK Frontend')
+      })
+  }
+)
 
 gulp.task(
   'copy:dm_toolkit_assets:stylesheets',
@@ -234,6 +245,7 @@ gulp.task('copy', gulp.parallel(
   'copy:dm_toolkit_assets:templates',
   'copy:images',
   'copy:svg',
+  'copy:govuk_frontend:stylesheets',
   'copy:govuk_frontend_assets:fonts',
   'copy:govuk_frontend_assets:images'
 ))

--- a/package-lock.json
+++ b/package-lock.json
@@ -2076,9 +2076,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-1.1.1.tgz",
-      "integrity": "sha512-dYrvUMnlri/XB8fI+aqFsu1Firsm1yEMf8wWQ2DdHVepwoWtGWQPFqmXrGg2TliipovXgLWha3jTZ65JFOyPtg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.0.0.tgz",
+      "integrity": "sha512-A3+j/gLT9NzOniffAmuHqx1cEfHb8MpfV0/LR4//taZAsigdabqoNRKD2/B0oZdNuRDOEBHtUywQEbEomADIaA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4050,6 +4050,11 @@
         }
       }
     },
+    "govuk-frontend": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.13.0.tgz",
+      "integrity": "sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw=="
+    },
     "govuk_frontend_toolkit": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-5.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^1.1.1",
+    "digitalmarketplace-govuk-frontend": "^2.0.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.0.0",
+    "govuk-frontend": "^2.13.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",


### PR DESCRIPTION
https://trello.com/c/fhL8Zl8T/175-3-unbundle-govuk-frontend-from-digitalmarketplace-govuk-frontend

This PR updates asset paths and template loading to work with the [new version of digitalmarketplace-govuk-frontend](https://github.com/alphagov/digitalmarketplace-govuk-frontend/releases/tag/v2.0.0), which no longer bundles govuk-frontend.