### PR TITLE
Replace alphagov/govuk-frontend-jinja with LandRegistry/govuk-frontend-jinja

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,8 +7,6 @@ import dmcontent.govuk_frontend
 from dmutils import init_app
 from dmutils.user import User
 
-from govuk_frontend_jinja.flask_ext import init_govuk_frontend
-
 from config import configs
 
 
@@ -21,9 +19,6 @@ def create_app(config_name):
     application = Flask(__name__,
                         static_folder='static/',
                         static_url_path=configs[config_name].STATIC_URL_PATH)
-
-    # allow using govuk-frontend Nunjucks templates
-    init_govuk_frontend(application)
 
     init_app(
         application,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from flask import Flask, request, redirect, session
 from flask_login import LoginManager
 from flask_wtf.csrf import CSRFProtect
@@ -16,10 +18,37 @@ data_api_client = dmapiclient.DataAPIClient()
 csrf = CSRFProtect()
 
 
+def init_jinja(app):
+    """Setup Jinja environment for app"""
+
+    # We create a hacked version of PackageLoader to work around the fact that
+    # the filenames are different in govuk_frontend_jinja
+    class GOVUKFrontendJinjaLoader(jinja2.PackageLoader):
+        def get_source(self, environment, template):
+            return super().get_source(environment, template.replace(".njk", ".html"))
+
+    repo_root = Path(__file__, "..", "..").resolve()
+    digitalmarketplace_govuk_frontend = repo_root / "node_modules" / "digitalmarketplace-govuk-frontend"
+
+    app.jinja_loader = jinja2.ChoiceLoader([
+        jinja2.FileSystemLoader([
+            repo_root / "app" / "templates",
+            digitalmarketplace_govuk_frontend,
+            digitalmarketplace_govuk_frontend / "digitalmarketplace" / "templates",
+        ]),
+        jinja2.PrefixLoader({
+            "govuk": GOVUKFrontendJinjaLoader("govuk_frontend_jinja"),
+            "govuk_frontend_jinja": jinja2.PackageLoader("govuk_frontend_jinja"),
+        })
+    ])
+
+
 def create_app(config_name):
     application = Flask(__name__,
                         static_folder='static/',
                         static_url_path=configs[config_name].STATIC_URL_PATH)
+
+    init_jinja(application)
 
     init_app(
         application,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, redirect, session
 from flask_login import LoginManager
 from flask_wtf.csrf import CSRFProtect
+import jinja2
 
 import dmapiclient
 import dmcontent.govuk_frontend
@@ -53,6 +54,9 @@ def create_app(config_name):
     application.jinja_env.globals["govuk_frontend_from_question"] = (
         dmcontent.govuk_frontend.from_question
     )
+
+    # allow looser attribute access in templates
+    application.jinja_env.undefined = jinja2.ChainableUndefined
 
     @application.before_request
     def remove_trailing_slash():

--- a/config.py
+++ b/config.py
@@ -67,9 +67,13 @@ class Config(object):
 
     @staticmethod
     def init_app(app):
+        class GOVUKFrontendJinjaLoader(jinja2.PackageLoader):
+            # work around the fact that the filenames are different in govuk_frontend_jinja
+            def get_source(self, environment, template):
+                return super().get_source(environment, template.replace(".njk", ".html"))
+
         repo_root = os.path.abspath(os.path.dirname(__file__))
         digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
-        govuk_frontend = os.path.join(repo_root, "node_modules", "govuk-frontend")
         template_folders = [
             os.path.join(repo_root, 'app', 'templates'),
             os.path.join(digitalmarketplace_govuk_frontend),
@@ -77,7 +81,10 @@ class Config(object):
         ]
         jinja_loader = jinja2.ChoiceLoader([
             jinja2.FileSystemLoader(template_folders),
-            jinja2.PrefixLoader({'govuk': jinja2.FileSystemLoader(govuk_frontend)})
+            jinja2.PrefixLoader({
+                "govuk": GOVUKFrontendJinjaLoader("govuk_frontend_jinja"),
+                "govuk_frontend_jinja": jinja2.PackageLoader("govuk_frontend_jinja"),
+            })
         ])
         app.jinja_loader = jinja_loader
 

--- a/config.py
+++ b/config.py
@@ -1,10 +1,7 @@
 import os
 import hashlib
-import jinja2
 from dmutils.status import get_version_label
 from dmutils.asset_fingerprint import AssetFingerprinter
-
-basedir = os.path.abspath(os.path.dirname(__file__))
 
 
 def get_asset_fingerprint(asset_file_path):
@@ -64,29 +61,6 @@ class Config(object):
     DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
     DM_APP_NAME = 'briefs-frontend'
-
-    @staticmethod
-    def init_app(app):
-        class GOVUKFrontendJinjaLoader(jinja2.PackageLoader):
-            # work around the fact that the filenames are different in govuk_frontend_jinja
-            def get_source(self, environment, template):
-                return super().get_source(environment, template.replace(".njk", ".html"))
-
-        repo_root = os.path.abspath(os.path.dirname(__file__))
-        digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
-        template_folders = [
-            os.path.join(repo_root, 'app', 'templates'),
-            os.path.join(digitalmarketplace_govuk_frontend),
-            os.path.join(digitalmarketplace_govuk_frontend, "digitalmarketplace", "templates"),
-        ]
-        jinja_loader = jinja2.ChoiceLoader([
-            jinja2.FileSystemLoader(template_folders),
-            jinja2.PrefixLoader({
-                "govuk": GOVUKFrontendJinjaLoader("govuk_frontend_jinja"),
-                "govuk_frontend_jinja": jinja2.PackageLoader("govuk_frontend_jinja"),
-            })
-        ])
-        app.jinja_loader = jinja_loader
 
 
 class Test(Config):

--- a/requirements.in
+++ b/requirements.in
@@ -6,8 +6,9 @@ Flask-Login==0.5.0
 Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
+Jinja2>=2.11.0
 govuk-frontend-jinja
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.20.0#egg=digitalmarketplace-content-loader==7.20.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.20.1#egg=digitalmarketplace-content-loader==7.20.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,8 @@ Flask-Login==0.5.0
 Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
+govuk-frontend-jinja
+
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.20.0#egg=digitalmarketplace-content-loader==7.20.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.3-alpha#egg=govuk-frontend-jinja==0.5.3-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,11 +29,11 @@ fleep==1.0.1              # via digitalmarketplace-utils
 future==0.18.2            # via notifications-python-client
 gds-metrics==0.2.0        # via digitalmarketplace-utils
 govuk-country-register==0.5.0  # via digitalmarketplace-utils
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.3-alpha#egg=govuk-frontend-jinja==0.5.3-alpha  # via -r requirements.in
+govuk-frontend-jinja==1.0.0  # via -r requirements.in
 idna==2.9                 # via cryptography, requests
 inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
-jinja2==2.10.3            # via digitalmarketplace-content-loader, flask, govuk-frontend-jinja
+jinja2==2.10.3            # via digitalmarketplace-content-loader, flask
 jmespath==0.9.4           # via boto3, botocore
 mailchimp3==3.0.6         # via digitalmarketplace-utils
 markdown==2.6.11          # via digitalmarketplace-content-loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.20.0#egg=digitalmarketplace-content-loader==7.20.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.20.1#egg=digitalmarketplace-content-loader==7.20.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
@@ -33,7 +33,7 @@ govuk-frontend-jinja==1.0.0  # via -r requirements.in
 idna==2.9                 # via cryptography, requests
 inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
-jinja2==2.10.3            # via digitalmarketplace-content-loader, flask
+jinja2==2.11.2            # via -r requirements.in, digitalmarketplace-content-loader, flask
 jmespath==0.9.4           # via boto3, botocore
 mailchimp3==3.0.6         # via digitalmarketplace-utils
 markdown==2.6.11          # via digitalmarketplace-content-loader

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -224,9 +224,8 @@ class BaseApplicationTest(object):
             assert expected_category == category
 
     def assert_breadcrumbs(self, response, extra_breadcrumbs=None):
-        breadcrumbs = html.fromstring(response.get_data(as_text=True)).xpath(
-            '//*[@class="govuk-breadcrumbs"]/ol/li'
-        )
+        document = html.fromstring(response.get_data(as_text=True))
+        breadcrumbs = document.cssselect(".govuk-breadcrumbs ol li")
 
         breadcrumbs_we_expect = [
             ('Digital Marketplace', '/'),

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -266,10 +266,7 @@ class TestAwardBriefDetails(BaseApplicationTest):
         page_title = self._strip_whitespace(document.xpath('//h1')[0].text_content())
         assert page_title == "TellusaboutyourcontractwithBananaCorp"
 
-        submit_button = document.xpath(
-            '//button[@type="submit"][normalize-space(string())=$t]',
-            t="Update requirements",
-        )
+        submit_button = document.cssselect(".govuk-button:contains('Update requirements')")
         assert len(submit_button) == 1
 
         secondary_action_link = document.xpath('//a[normalize-space(text())="Previous page"]')[0]


### PR DESCRIPTION
We want to use the Jinja govuk-frontend templates built by the HMLR team at https://github.com/LandRegistry/govuk-frontend-jinja.

There are a couple of workarounds/tweaks needed to get it all working:

- We need to upgrade Jinja2 to 2.11 so we can use ChainableUndefined, otherwise attribute accesses such as `errors.email_address.errorMessage` will raise an exception
- We need to do add LandRegistry/govuk_frontend_jinja to the loader twice, and workaround the fact that its filenames end with `.html` instead of `.njk`

Also, we shouldn't deploy this to production, because LandRegistry/govuk_frontend_jinja assumes govuk-frontend v3 assets, so JavaScript features such as error summary links won't work (as the `data-` attribute values change between v2 and v3).

This PR should help keep the complexity of #353 down though.
