### PR TITLE
Styling and template tweaks to prepare for version 3 of govuk-frontend

### DIFF
--- a/app/assets/scss/overrides/_summary-list.scss
+++ b/app/assets/scss/overrides/_summary-list.scss
@@ -37,7 +37,7 @@
 .app-no-summary-content {
     color: $secondary-text-colour;
     @include core-16;
-    margin: 0 0 15px 0;
+    margin-bottom: govuk-spacing(7);
     border-top: 1px solid $border-colour;
     border-bottom: 1px solid $border-colour;
     padding-top: 10px;

--- a/app/assets/scss/overrides/_task-list.scss
+++ b/app/assets/scss/overrides/_task-list.scss
@@ -5,6 +5,10 @@
     padding-left: 0;
     margin-top: 0;
     margin-bottom: 0;
+    
+    h2:first-of-type {
+      margin-top: 0;
+    }
 
     &__section {
       @include govuk-responsive-margin(7, "bottom");

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -256,13 +256,15 @@
         {% endwith %}
     </div>
     <div class="govuk-grid-column-one-third">
-      {% if brief.status == 'closed' %}
-        <a class="govuk-link" href="{{ url_for('buyers.cancel_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel requirements</a>
-      {% elif brief.status == 'live' %}
-        <a class="govuk-link" href="{{ url_for('buyers.withdraw_a_brief_warning', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Withdraw requirements</a>
-      {% elif brief.status == 'draft' %}
-        <a class="govuk-link" href="{{ url_for('buyers.delete_a_brief_warning', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Delete draft requirements</a>
-      {% endif %}
+      <p class="govuk-body">
+        {% if brief.status == 'closed' %}
+          <a class="govuk-link" href="{{ url_for('buyers.cancel_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Cancel requirements</a>
+        {% elif brief.status == 'live' %}
+          <a class="govuk-link" href="{{ url_for('buyers.withdraw_a_brief_warning', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Withdraw requirements</a>
+        {% elif brief.status == 'draft' %}
+          <a class="govuk-link" href="{{ url_for('buyers.delete_a_brief_warning', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Delete draft requirements</a>
+        {% endif %}
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -146,10 +146,12 @@
       {% endif %}
 
     {%- endif %}
-    <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
-       href="{{ url_for('.view_brief_overview', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
-      Return to overview
-    </a>
+    <p class="govuk-body">
+      <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
+        href="{{ url_for('.view_brief_overview', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
+        Return to overview
+      </a>
+    </p>
   </div>
 </div>
 

--- a/app/templates/buyers/edit_brief_question.html
+++ b/app/templates/buyers/edit_brief_question.html
@@ -59,10 +59,12 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <a class="govuk-link govuk-!-margin-top-3 govuk-!-display-inline-block"
-         href="{{ brief_links.brief_link_url('child', section, brief) }}">
-        {{ "Return to {}".format(section.name|lower if section.has_summary_page else 'overview') }}
-      </a>
+      <p class="govuk-body">
+        <a class="govuk-link govuk-!-margin-top-3 govuk-!-display-inline-block"
+          href="{{ brief_links.brief_link_url('child', section, brief) }}">
+          {{ "Return to {}".format(section.name|lower if section.has_summary_page else 'overview') }}
+        </a>
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
Includes:

* Tweaks to Task List and Summary List styles to offset slight changes in version 3 of govuk-frontend. These changes don't adversely affect the current components.
* Wrapping `<a>` tags with `<p>` tags - in v3, the font size of unwrapped `<a>` tags defaults to a smaller size. This change catches the last few examples and wraps them to avoid that.