### PR TITLE
Add test for function of dmAlert for flash messages

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -223,6 +223,22 @@ class BaseApplicationTest(object):
             assert expected_message in message, "Didn't find '{}' in '{}'".format(expected_message, message)
             assert expected_category == category
 
+    def assert_flashes_with_dm_alert(self, expected_message, expected_category):
+        # Test a flash message renders as a dmAlert. The flash message
+        # should show on the next page visited (whether or not it is the
+        # page expected from the redirect).
+        res = self.client.get("/buyers/404")
+        assert res.status_code == 404
+
+        document = html.fromstring(res.get_data(as_text=True))
+        dm_alert = document.cssselect(".dm-alert")
+        assert len(dm_alert) == 1
+
+        if expected_category == "success":
+            assert dm_alert[0].cssselect(".dm-alert__title")[0].text_content().strip() == expected_message
+        else:
+            assert dm_alert[0].cssselect(".dm-alert__body")[0].text_content().strip() == expected_message
+
     def assert_breadcrumbs(self, response, extra_breadcrumbs=None):
         breadcrumbs = html.fromstring(response.get_data(as_text=True)).xpath(
             '//*[@class="govuk-breadcrumbs"]/ol/li'

--- a/tests/main/views/create_a_brief/test_delete.py
+++ b/tests/main/views/create_a_brief/test_delete.py
@@ -92,10 +92,11 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
         assert res.status_code == 302
         assert self.data_api_client.delete_brief.called
         assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-        self.assert_flashes(
-            "Your requirements ‘I need a thing to do a thing’ were deleted",
-            expected_category="success"
-        )
+
+        expected_message = "Your requirements ‘I need a thing to do a thing’ were deleted"
+        expected_category = "success"
+        self.assert_flashes(expected_message, expected_category)
+        self.assert_flashes_with_dm_alert(expected_message, expected_category)
 
     def test_404_if_framework_is_not_live_or_expired(self):
         for framework_status in ['coming', 'open', 'pending', 'standstill']:

--- a/tests/main/views/test_buyers.py
+++ b/tests/main/views/test_buyers.py
@@ -247,7 +247,11 @@ class TestBuyerRoleRequired(BaseApplicationTest):
         assert res.location == 'http://localhost/user/login?next={}'.format(
             self.briefs_dashboard_url.replace('/', '%2F')
         )
-        self.assert_flashes('You must log in with a buyer account to see this page.', expected_category='error')
+
+        expected_message = "You must log in with a buyer account to see this page."
+        expected_category = "error"
+        self.assert_flashes(expected_message, expected_category)
+        self.assert_flashes_with_dm_alert(expected_message, expected_category)
 
     def test_buyer_pages_ok_if_logged_in_as_buyer(self):
         self.login_as_buyer()

--- a/tests/main/views/test_outcome.py
+++ b/tests/main/views/test_outcome.py
@@ -302,7 +302,11 @@ class TestAwardBriefDetails(BaseApplicationTest):
         )
         assert res.status_code == 302
         assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", expected_category="success")
+
+        expected_message = "You’ve updated ‘I need a thing to do a thing’"
+        expected_category = "success"
+        self.assert_flashes(expected_message, expected_category)
+        self.assert_flashes_with_dm_alert(expected_message, expected_category)
 
     @mock.patch('app.main.views.outcome.is_brief_correct')
     def test_award_brief_details_raises_400_if_brief_not_correct(self, is_brief_correct):
@@ -607,7 +611,11 @@ class TestCancelBrief(BaseApplicationTest):
 
         assert res.status_code == 302
         assert expected_url in redirect_text
-        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", expected_category="success")
+
+        expected_message = "You’ve updated ‘I need a thing to do a thing’"
+        expected_category = "success"
+        self.assert_flashes(expected_message, expected_category)
+        self.assert_flashes_with_dm_alert(expected_message, expected_category)
 
 
 class TestAwardOrCancelBrief(BaseApplicationTest):
@@ -721,7 +729,10 @@ class TestAwardOrCancelBrief(BaseApplicationTest):
         self.login_as_buyer()
         self.client.post(self.url.format(brief_id=self.brief['id']), data={'award_or_cancel_decision': 'back'})
 
-        self.assert_flashes("You’ve updated ‘I need a thing to do a thing’", expected_category="success")
+        expected_message = "You’ve updated ‘I need a thing to do a thing’"
+        expected_category = "success"
+        self.assert_flashes(expected_message, expected_category)
+        self.assert_flashes_with_dm_alert(expected_message, expected_category)
 
     def test_random_post_data_triggers_invalid_choice(self):
         self.login_as_buyer()

--- a/tests/main/views/test_withdraw_brief.py
+++ b/tests/main/views/test_withdraw_brief.py
@@ -104,10 +104,10 @@ class TestWithdrawBriefSubmission(BaseApplicationTest):
         assert res.status_code == 302
         assert self.data_api_client.delete_brief.call_args_list == []
         assert res.location == "http://localhost{}".format(self.briefs_dashboard_url)
-        self.assert_flashes(
-            "You’ve withdrawn your requirements for ‘I need a thing to do a thing’",
-            expected_category="success"
-        )
+
+        expected_flash_message = ("You’ve withdrawn your requirements for ‘I need a thing to do a thing’", "success")
+        self.assert_flashes(*expected_flash_message)
+        self.assert_flashes_with_dm_alert(*expected_flash_message)
 
     @pytest.mark.parametrize('framework_status', ['coming', 'open', 'pending', 'standstill'])
     def test_404_if_framework_is_not_live_or_expired(self, framework_status):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -64,12 +64,16 @@ class TestApplication(BaseApplicationTest):
                 data={'anything': 'here'},
             )
 
-            self.assert_flashes("Your session has expired. Please log in again.", expected_category="error")
             assert res.status_code == 302
 
             # POST requests will not preserve the request path on redirect
             assert res.location == 'http://localhost/user/login'
             assert validate_csrf.call_args_list == [mock.call(None)]
+
+            expected_message = "Your session has expired. Please log in again."
+            expected_category = "error"
+            self.assert_flashes(expected_message, expected_category)
+            self.assert_flashes_with_dm_alert(expected_message, expected_category)
 
     def test_should_use_local_cookie_page_on_cookie_message(self):
         res = self.client.get('/buyers')


### PR DESCRIPTION
While trying to migrate this app to LandRegistry/govuk-frontend-jinja I got caught out by an issue with the `dmAlert` component that wasn't tested by our unit tests but was tested by our functional tests. We should test that the template works in our unit tests.