### PR TITLE
Add `<p>` wrap around `<a>` tag

### DIFF
--- a/app/templates/buyers/award.html
+++ b/app/templates/buyers/award.html
@@ -96,10 +96,10 @@
         }) }}
       {% endblock %}
     </form>
-    <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
+    <p class="govuk-body"><a class="govuk-link"
         href="{{ url_for('.award_or_cancel_brief', framework_slug=brief.framework.slug, lot_slug=brief['lotSlug'], brief_id=brief['id']) }}">
       Previous page
-    </a>
+    </a></p>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/buyers/award_details.html
+++ b/app/templates/buyers/award_details.html
@@ -61,10 +61,10 @@
             }) }}
           {% endblock %}
       </form>
-      <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
+      <p class="govuk-body"><a class="govuk-link"
          href="{{ url_for('.award_brief', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
         Previous page
-      </a>
+      </a></p>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -67,10 +67,10 @@
           </ol>
           
           <div class="govuk-width-full">
-            <a class="govuk-link" 
+            <p class="govuk-body"><a class="govuk-link" 
                 href="{{ url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}"
                 download
-            >Download supplier responses to this requirement (ODS)</a>
+            >Download supplier responses to this requirement (ODS)</a></p>
           </div>
 
         {% else %}
@@ -84,10 +84,10 @@
           </p>
 
           <div class="govuk-width-full">
-            <a class="govuk-link" 
+            <p class="govuk-body"><a class="govuk-link" 
                 href="{{ url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}"
                 download
-            >Download supplier responses to ‘{{ brief.get('title', brief['lotName']) }}’ (CSV)</a>
+            >Download supplier responses to ‘{{ brief.get('title', brief['lotName']) }}’ (CSV)</a></p>
           </div>
 
         {% endif %}
@@ -108,10 +108,10 @@
             <li>rewriting your requirements</li>
         </ul>
       {% endif %}
-      <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block"
+      <p class="govuk-body"><a class="govuk-link"
          href="{{ url_for('buyers.view_brief_overview', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">
         Back to overview
-      </a>
+      </a></p>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/buyers/cancel_brief.html
+++ b/app/templates/buyers/cancel_brief.html
@@ -94,7 +94,7 @@
           }) }}
         {% endblock %}
       </form>
-      <a class="govuk-link govuk-!-margin-top-6 govuk-!-display-inline-block" href="{{ previous_page_url }}">Previous page</a>
+      <p class="govuk-body"><a class="govuk-link" href="{{ previous_page_url }}">Previous page</a></p>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/buyers/edit_brief_question.html
+++ b/app/templates/buyers/edit_brief_question.html
@@ -60,7 +60,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <p class="govuk-body">
-        <a class="govuk-link govuk-!-margin-top-3 govuk-!-display-inline-block"
+        <a class="govuk-link"
           href="{{ brief_links.brief_link_url('child', section, brief) }}">
           {{ "Return to {}".format(section.name|lower if section.has_summary_page else 'overview') }}
         </a>

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -68,9 +68,11 @@
     <p class="govuk-body">Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
         
     <h2 class="govuk-heading-m">Download the list of labs</h2>
-    <a class="govuk-link govuk-!-display-inline-block govuk-!-margin-bottom-6" 
+    <p class="govuk-body">
+      <a class="govuk-link" 
         href="{{ 'https://assets.digitalmarketplace.service.gov.uk/{}/communications/catalogues/user-research-studios.csv'.format(framework.slug) }}"      
-    >List of labs (CSV)</a>
+      >List of labs (CSV)</a>
+    </p>
 
     <p class="govuk-body">Get help filtering the list at <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>
 


### PR DESCRIPTION
Spotted a lot more of these during manual testing of v3 migration. In v3 of govuk-frontend, links are not automatically sized to paragraph font size, so we need to be more explicit.

There are a few instances of links being aligned through overrides - I think it's better to just use a `<p>` wrap - I think the spacing looks good, though I can revert these if other disagree.