### PR TITLE
Bump govuk-frontend to 3.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4027,9 +4027,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.9.0.tgz",
-      "integrity": "sha512-RxlgKJzlFzKPKd0reUC9/xzR2MJ2x0Ky0VK+ikndVkgODKT+Lpt3qIKEqhuJ4aGpBGOxZV9Cha+CkxYdE7GDHQ=="
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.9.1.tgz",
+      "integrity": "sha512-ouOoDUj0QwDA4uCHIBkGCFMpORuTRcSuDscOrz7V1PBcOecntLglxJAZAuNm+j2sPo7anoScHU0ZSeE2QIoeAg=="
     },
     "graceful-fs": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3",
     "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r2",
-    "govuk-frontend": "^3.9.0",
+    "govuk-frontend": "^3.9.1",
     "gulp": "^4.0.2",
     "gulp-filelog": "0.4.1",
     "gulp-include": "^2.4.1",


### PR DESCRIPTION
https://trello.com/c/OBFVKC3p/241-1-bump-govuk-frontend-to-391-on-briefs-and-user

We need to bump govuk-frontend to 3.9.1 to fix an accessibility bug:
https://github.com/alphagov/govuk-frontend/releases/tag/v3.9.1