### PR TITLE
Bump digitalmarketplace-govuk-frontend to 3.0.0-govuk-frontend-3-r4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2068,8 +2068,8 @@
       "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3"
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "github:alphagov/digitalmarketplace-govuk-frontend#109da251de4a4ccfc65cd0ae7c7d30c143712e55",
-      "from": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r3"
+      "version": "github:alphagov/digitalmarketplace-govuk-frontend#a3b81969f53fe6b609b90e90f1dfa14145de015e",
+      "from": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r4"
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3",
-    "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r3",
+    "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r4",
     "govuk-frontend": "^3.9.1",
     "gulp": "^4.0.2",
     "gulp-filelog": "0.4.1",


### PR DESCRIPTION
Fixes a bug with the list input component; if there is an error the error summary would not link to the component correctly.