### PR TITLE
Load DOS 5 content 

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -41,6 +41,12 @@ def _make_content_loader_factory():
     master_cl.load_manifest('digital-outcomes-and-specialists-4', 'clarification_question', 'clarification_question')
     master_cl.load_manifest('digital-outcomes-and-specialists-4', 'briefs', 'award_brief')
 
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'briefs', 'edit_brief')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'briefs', 'display_brief')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'brief-responses', 'output_brief_response')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'clarification_question', 'clarification_question')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'briefs', 'award_brief')
+
     # seal master_cl in a closure by returning a function which will only ever return an independent copy of it
     return lambda: deepcopy(master_cl)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,8 +2064,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#99290ee125d589213b35a5e61dce39f7e59de089",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#f4f21674fb33c32394b1a1e1c09059ebd8bd41e0",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.6"
     },
     "digitalmarketplace-govuk-frontend": {
       "version": "github:alphagov/digitalmarketplace-govuk-frontend#a3b81969f53fe6b609b90e90f1dfa14145de015e",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.10.3",
+    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.6",
     "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r4",
     "govuk-frontend": "^3.9.1",
     "gulp": "^4.0.2",


### PR DESCRIPTION
This is needed for making DOS 5 live. I don't know how/why we missed doing it earlier. Should un-break Preview.

Following the example from DOS 4: https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/196