### PR TITLE
Bump digitalmarketplace-frameworks version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,8 +2064,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#f4f21674fb33c32394b1a1e1c09059ebd8bd41e0",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.6"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#26b376bf1ec406da53491d8398d882552a2fff1c",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.7"
     },
     "digitalmarketplace-govuk-frontend": {
       "version": "github:alphagov/digitalmarketplace-govuk-frontend#a3b81969f53fe6b609b90e90f1dfa14145de015e",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.6",
+    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.7",
     "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r4",
     "govuk-frontend": "^3.9.1",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Pick up the updated example content added in https://github.com/alphagov/digitalmarketplace-frameworks/pull/666

https://trello.com/c/bQUiYaju/702-update-date-examples-to-2021