### PR TITLE
Bump digitalmarketplace-test-utils from git to PyPI

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ Flask-Login==0.5.0
 Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
+digitalmarketplace-content-loader
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.28.1#egg=digitalmarketplace-content-loader==7.28.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.4-alpha#egg=govuk-frontend-jinja==0.5.4-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ defusedxml==0.6.0
     # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.7.0#egg=digitalmarketplace-apiclient==21.7.0
     # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.28.1#egg=digitalmarketplace-content-loader==7.28.1
+digitalmarketplace-content-loader==7.28.1
     # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
     # via


### PR DESCRIPTION
We want to install digitalmarketplace-content-loader from PyPI instead of VCS, so we can rely on Dependabot to update our apps automatically when a new version is available.