### PR TITLE
Bump digitalmarketplace-frameworks version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,8 +2064,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#26b376bf1ec406da53491d8398d882552a2fff1c",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.7"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#e0ba46210b7754372a688cebb362c5a94743da7e",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.8"
     },
     "digitalmarketplace-govuk-frontend": {
       "version": "github:alphagov/digitalmarketplace-govuk-frontend#a3b81969f53fe6b609b90e90f1dfa14145de015e",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.7",
+    "digitalmarketplace-frameworks": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.8",
     "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r4",
     "govuk-frontend": "^3.9.1",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Pick up the new contract links added in https://github.com/alphagov/digitalmarketplace-frameworks/pull/667

https://trello.com/c/fjMThOjv/703-1-send-buyers-to-the-correct-dos5-standard-contract-link