### PR TITLE
remove unneeded apt dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Ubuntu packages
-      run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
-
     - name: Install Node dependencies
       shell: bash -l {0}
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,11 @@ jobs:
       with:
         path: venv
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: venv-${{ runner.os }}-${{ matrix.python-version }}-
+
+    - name: Install python dependencies
+      run: make requirements-dev
+      if: steps.python-cache.outputs.cache-hit != 'true'
 
     - name: Run python tests
-      run: |
-        make requirements-dev
-        make test
+      run: make test


### PR DESCRIPTION
following the upgrade of lxml in https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/377 we no longer need these additional `apt` dependencies