### PR TITLE
prevent 500 when viewing timeline after publishing brief

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -87,9 +87,9 @@
                 "href": url_for('.edit_brief_question', framework_slug=brief.framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id),
                 "text": "Edit",
                 "visuallyHiddenText": "question and answer session details"
-              }
+              } if not published else None
             ]
-          } if not published and questionDetails
+          } if questionDetails else None
         } %}
       
         {{ govukSummaryList({

--- a/tests/main/views/create_a_brief/test_publish.py
+++ b/tests/main/views/create_a_brief/test_publish.py
@@ -716,6 +716,7 @@ class TestViewQuestionAndAnswerDates(BaseApplicationTest):
             brief_json['briefs']['clarificationQuestionsPublishedBy'] = u"2016-04-14T23:59:00.00000Z"
             brief_json['briefs']['applicationsClosedAt'] = u"2016-04-16T23:59:00.00000Z"
             brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']['questionAndAnswerSessionDetails'] = 'question and answer session details'
             brief_json['briefs']["clarificationQuestionsAreClosed"] = True
             self.data_api_client.get_brief.return_value = brief_json
 
@@ -731,8 +732,9 @@ class TestViewQuestionAndAnswerDates(BaseApplicationTest):
             assert all(
                 date in
                 [e.text_content().strip() for e in document.xpath('//main//dt')]
-                for date in ['2 April', '8 April', '15 April', '16 April']
+                for date in ['2 April', 'Before 8 April', '8 April', '15 April', '16 April']
             )
+            assert 'question and answer session details' in document.xpath('//main//dd')[1].text_content().strip()
 
     def test_404_if_framework_is_not_live_or_expired(self):
         for framework_status in ['coming', 'open', 'pending', 'standstill']:


### PR DESCRIPTION
https://trello.com/c/jOWgypcV/2197-500-error-on-https-wwwdigitalmarketplaceservicegovuk-buyers-frameworks-digital-outcomes-and-specialists-5-requirements-digital-o
Previously we didn't handle the case where the buyer viewed the timeline after publishing an opportunity with a question and answer session. This was previously causing a 500 as the behaviour for the condition was not specified. 

The intended behaviour in this case; as confirmed by @NoraGDS; is that they can still see the question and answer session on the timeline after publishing (but without the Edit link). This is what is implemented by this PR.

![Screenshot 2021-04-07 at 14 24 49](https://user-images.githubusercontent.com/1764158/113873782-07260280-97ad-11eb-9f2b-9d731f4f4973.png)
