### PR TITLE
Revert "Give me access to download a brief responses file"

### DIFF
--- a/app/main/helpers/buyers_helpers.py
+++ b/app/main/helpers/buyers_helpers.py
@@ -26,25 +26,6 @@ def is_brief_correct(brief, framework_slug, lot_slug, current_user_id, allow_wit
     )
 
 
-def is_brief_correct_debug(
-        brief, framework_slug, lot_slug, current_user_id, allow_withdrawn=False, allowed_statuses=None
-):
-    """
-    Allow a developer (BG) to act as if they were the owner of a particular brief. Needed to try to replicate an odd
-    file download error.
-
-    TODO: delete after use.
-    """
-    return (
-        brief['frameworkSlug'] == framework_slug
-        and brief['lotSlug'] == lot_slug
-        and (is_brief_associated_with_user(brief, current_user_id) or
-             (current_user_id == 64002 and brief['id'] == 14339))
-        and (True if allow_withdrawn else not brief_is_withdrawn(brief))
-        and (brief['status'] in allowed_statuses if allowed_statuses else True)
-    )
-
-
 def is_brief_associated_with_user(brief, current_user_id):
     user_ids = [user.get('id') for user in brief.get('users', [])]
     return current_user_id in user_ids

--- a/app/main/views/download_responses.py
+++ b/app/main/views/download_responses.py
@@ -8,7 +8,7 @@ from flask_login import current_user
 from app import data_api_client
 from .buyers import CLOSED_PUBLISHED_BRIEF_STATUSES
 from .. import main, content_loader
-from ..helpers.buyers_helpers import get_framework_and_lot, get_sorted_responses_for_brief, is_brief_correct_debug
+from ..helpers.buyers_helpers import get_framework_and_lot, get_sorted_responses_for_brief, is_brief_correct
 
 from dmutils.views import DownloadFileView
 
@@ -52,8 +52,8 @@ class DownloadBriefResponsesView(DownloadFileView):
 
         brief = self.data_api_client.get_brief(kwargs['brief_id'])["briefs"]
 
-        if not is_brief_correct_debug(brief, kwargs['framework_slug'],
-                                      kwargs['lot_slug'], current_user.id):
+        if not is_brief_correct(brief, kwargs['framework_slug'],
+                                kwargs['lot_slug'], current_user.id):
             abort(404)
 
         if brief['status'] not in CLOSED_PUBLISHED_BRIEF_STATUSES:

--- a/tests/main/views/test_download_responses.py
+++ b/tests/main/views/test_download_responses.py
@@ -240,15 +240,15 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
         self.instance.data_api_client.get_brief.return_value = brief
 
         with po(download_responses, 'get_framework_and_lot'),\
-                po(download_responses, 'is_brief_correct_debug') as is_brief_correct_debug,\
+                po(download_responses, 'is_brief_correct') as is_brief_correct,\
                 mock.patch.object(download_responses, 'current_user') as current_user:
 
             result = self.instance.get_file_context(**kwargs)
 
-        is_brief_correct_debug.assert_called_once_with(brief['briefs'],
-                                                       kwargs['framework_slug'],
-                                                       kwargs['lot_slug'],
-                                                       current_user.id)
+        is_brief_correct.assert_called_once_with(brief['briefs'],
+                                                 kwargs['framework_slug'],
+                                                 kwargs['lot_slug'],
+                                                 current_user.id)
 
         self.instance.data_api_client.get_brief\
             .assert_called_once_with(kwargs['brief_id'])
@@ -275,10 +275,10 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
         self.instance.data_api_client.get_brief.return_value = brief
 
         with po(download_responses, 'get_framework_and_lot'),\
-                po(download_responses, 'is_brief_correct_debug') as is_brief_correct_debug,\
+                po(download_responses, 'is_brief_correct') as is_brief_correct,\
                 mock.patch.object(download_responses, 'current_user'):
 
-            is_brief_correct_debug.return_value = False
+            is_brief_correct.return_value = False
             with pytest.raises(NotFound):
                 self.instance.get_file_context(**kwargs)
 
@@ -299,10 +299,10 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
         self.instance.data_api_client.get_brief.return_value = brief
 
         with po(download_responses, 'get_framework_and_lot'),\
-                po(download_responses, 'is_brief_correct_debug') as is_brief_correct_debug,\
+                po(download_responses, 'is_brief_correct') as is_brief_correct,\
                 mock.patch.object(download_responses, 'current_user'):
 
-            is_brief_correct_debug.return_value = True
+            is_brief_correct.return_value = True
             with pytest.raises(NotFound):
                 self.instance.get_file_context(**kwargs)
 


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4533642

I've downloaded the response file in question and got what I needed for my investigation. We should now revert this to remove my hacky access.

Reverts alphagov/digitalmarketplace-briefs-frontend#427