### PR TITLE
Upgrade to Flask 1.1.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements.in
 
-Flask==1.0.4
+Flask>=1.1,<2
 Flask-Login==0.5.0
 Flask-WTF==0.14.3
-itsdangerous==1.1.0
+itsdangerous
 
 digitalmarketplace-apiclient
 digitalmarketplace-content-loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,9 +30,9 @@ defusedxml==0.6.0
     # via odfpy
 digitalmarketplace-apiclient==22.0.0
     # via -r requirements.in
-digitalmarketplace-content-loader==8.0.0
+digitalmarketplace-content-loader==8.1.0
     # via -r requirements.in
-digitalmarketplace-utils==58.1.0
+digitalmarketplace-utils==59.0.0
     # via
     #   -r requirements.in
     #   digitalmarketplace-content-loader
@@ -52,7 +52,7 @@ flask-wtf==0.14.3
     # via
     #   -r requirements.in
     #   digitalmarketplace-utils
-flask==1.0.4
+flask==1.1.4
     # via
     #   -r requirements.in
     #   digitalmarketplace-content-loader
@@ -137,9 +137,7 @@ urllib3==1.25.10
     #   botocore
     #   requests
 werkzeug==1.0.0
-    # via
-    #   digitalmarketplace-utils
-    #   flask
+    # via flask
 workdays==1.4
     # via digitalmarketplace-utils
 wtforms==2.2.1


### PR DESCRIPTION
Pin requirements to 1.1 or greater, but less than 2. Flask 1.1 is the last planned v1 release before 2.0.0, so take patch versions of 1.1 for security but not 2.0 which we're not ready for yet.

Take new versions of utils and content-loader which have been updated for Flask 1.1

Also remove the pin for `itsdangerous` - Flask now controls the supported versions. See https://github.com/pallets/flask/blob/1.1.4/setup.py#L58

Essentially the same as https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1436

https://trello.com/c/obh5gpQp/2250-update-to-flask-114