### PR TITLE
Rename labs to studios

### DIFF
--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -65,7 +65,7 @@
       <li>Award a contract to the supplier that best meets your needs.</li>
     </ol>
 
-    <p class="govuk-body">Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
+    <p class="govuk-body">Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research studios</a>.</p>
         
     <h2 class="govuk-heading-m">Download the list of studios</h2>
     <p class="govuk-body">

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Find a user research lab - Digital Marketplace
+  Find a user research studio - Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -22,10 +22,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Find a user research lab</h1>
+    <h1 class="govuk-heading-l">Find a user research studio</h1>
     
     <p class="govuk-body">
-      To find a user research lab, you need to tell suppliers what facilities you need and when. They’ll then tell you what they can do and how much it will cost.
+      To find a user research studio, you need to tell suppliers what facilities you need and when. They’ll then tell you what they can do and how much it will cost.
     </p>
 
     <h2 class="govuk-heading-m">Before you start</h2>
@@ -39,8 +39,8 @@
 
     <h2 class="govuk-heading-m">Create a shortlist</h2>
     <ol class="govuk-list govuk-list--number" start="3">
-      <li>Download the list of user research labs from the Digital Marketplace.</li>
-      <li>Filter the list of labs on location and your requirements to create a shortlist.</li>
+      <li>Download the list of user research studios from the Digital Marketplace.</li>
+      <li>Filter the list of studios on location and your requirements to create a shortlist.</li>
     </ol>
 
     <h2 class="govuk-heading-m">Contact your shortlist</h2>
@@ -67,11 +67,11 @@
 
     <p class="govuk-body">Read more about <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
         
-    <h2 class="govuk-heading-m">Download the list of labs</h2>
+    <h2 class="govuk-heading-m">Download the list of studios</h2>
     <p class="govuk-body">
       <a class="govuk-link" 
         href="{{ 'https://assets.digitalmarketplace.service.gov.uk/{}/communications/catalogues/user-research-studios.csv'.format(framework.slug) }}"      
-      >List of labs (CSV)</a>
+      >List of studios (CSV)</a>
     </p>
 
     <p class="govuk-body">Get help filtering the list at <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a></p>

--- a/tests/main/views/test_digital_outcomes_and_specialists.py
+++ b/tests/main/views/test_digital_outcomes_and_specialists.py
@@ -122,7 +122,7 @@ class TestStartStudiosInfoPage(BaseApplicationTest):
             "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/user-research-studios")
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
-        assert document.xpath('//h1')[0].text_content().strip() == "Find a user research lab"
+        assert document.xpath('//h1')[0].text_content().strip() == "Find a user research studio"
 
     @pytest.mark.parametrize(('slug_suffix'), ('', '-2', '-3'))
     def test_has_correct_link_to_supplier_csv(self, slug_suffix):
@@ -140,7 +140,7 @@ class TestStartStudiosInfoPage(BaseApplicationTest):
 
         document = html.fromstring(res.get_data(as_text=True))
 
-        assert document.xpath("//a[normalize-space(text())='List of labs (CSV)']")[0].attrib['href'] == (
+        assert document.xpath("//a[normalize-space(text())='List of studios (CSV)']")[0].attrib['href'] == (
             f"https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists{slug_suffix}"
             f"/communications/catalogues/user-research-studios.csv"
         )


### PR DESCRIPTION
https://trello.com/c/ohDPcudm/606-1-change-dos-page-title-user-research-studios
We want to rename user research labs to studios to reflect the current name of the lot.