### PR TITLE
Revert "Bump digitalmarketplace-frameworks to 18.3.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2884,9 +2884,9 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-frameworks/-/digitalmarketplace-frameworks-18.3.0.tgz",
-      "integrity": "sha512-X2LccFRe5kQwvkEy36pW6ByIDGPJkM9KgZl94hql/lh3AlHMT7cnl61DIKIxiouqbon6+T2qOhZcZymJggIlxA=="
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-frameworks/-/digitalmarketplace-frameworks-18.2.2.tgz",
+      "integrity": "sha512-sFgUQp0NOMgt13fNmaC/DD7YFYLGYDsp5WXiyu6+fXM5MIEg/kLxueXx+2t/mVrysX9M5D+TlUZLkOHA+uYhUw=="
     },
     "digitalmarketplace-govuk-frontend": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^6.0.0",
-    "digitalmarketplace-frameworks": "^18.3.0",
+    "digitalmarketplace-frameworks": "^18.2.2",
     "digitalmarketplace-govuk-frontend": "^3.0.1",
     "govuk-frontend": "^3.12.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-briefs-frontend#447

Reverting to unblock the pipeline while I fix some functional tests that we didn't find yesterday. 